### PR TITLE
fix(systemPromptSync): skip prompts with empty id when loading replacements

### DIFF
--- a/src/systemPromptSync.ts
+++ b/src/systemPromptSync.ts
@@ -1426,6 +1426,10 @@ export const loadSystemPromptsWithRegex = async (
 
   // For each prompt in strings.json
   for (const jsonPrompt of stringsJson.prompts) {
+    if (!jsonPrompt.id) {
+      continue;
+    }
+
     // Build the search regex from pieces array
     const regex = buildSearchRegexFromPieces(
       jsonPrompt.pieces,


### PR DESCRIPTION
## Summary

`loadSystemPromptsWithRegex` builds the markdown path as `path.join(SYSTEM_PROMPTS_DIR, '${jsonPrompt.id}.md')`, so any prompt entry with an empty `id` resolves to `.md` and triggers ENOENT on `--apply`.

`data/prompts/prompts-2.1.142.json` ships two such entries — orphaned *"Your version of Claude Code … is too old for Remote Control"* strings the extractor failed to label (id, name, and description all empty). Older versions don't have them:

| Version | empty-id entries | total prompts |
|---|---:|---:|
| 2.1.140 | 0 | 293 |
| 2.1.141 | 0 | 324 |
| 2.1.142 | **2** | 338 |

## Repro

```
$ node dist/index.mjs --apply
…
Failed to read markdown file /Users/<me>/.tweakcc/system-prompts/.md: Error: ENOENT: no such file or directory, open '/Users/<me>/.tweakcc/system-prompts/.md'
    at async open (node:internal/fs/promises:642:25)
    at async Module.readFile (node:internal/fs/promises:1279:14)
    at async Et (config-*.mjs)
    at async jt (config-*.mjs)
    …
```

Printed twice (once per malformed entry).

## Fix

Add `if (!jsonPrompt.id) continue;` at the top of the loop in `loadSystemPromptsWithRegex`, mirroring the existing `!prompt.name` guard already in `syncPrompt`. Patches that did apply before still apply; the two redundant ENOENT lines no longer print.

## Notes

- A more thorough fix would be to label those two strings in the extractor so they become overridable named prompts. They are real CC 2.1.142 content, just orphaned. That's a separate change.
- `pnpm test` passes (238 tests). `npx prettier --check src/systemPromptSync.ts` clean.
