### PR TITLE
fix: default claudemdContextOncePerConversation OFF (silently drops CLAUDE.md from turn 2 onward)

### DIFF
--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -722,7 +722,7 @@ export const DEFAULT_SETTINGS: Settings = {
     maxEffortDefault: false,
     autoModeClassifierModel: 'default',
     suppressDeferredTools: false,
-    claudemdContextOncePerConversation: true,
+    claudemdContextOncePerConversation: false,
   },
   toolsets: [],
   defaultToolset: null,

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -481,7 +481,7 @@ const PATCH_DEFINITIONS = [
     name: 'claudeMd context: once per conversation',
     group: PatchGroup.SYSTEM_REMINDERS,
     description:
-      'Inject the claudeMd / userEmail / currentDate <system-reminder> only on the first API call per conversation (re-fires after /clear). Default: ON. Toggle OFF for vanilla CC per-turn injection.',
+      'Inject the claudeMd / userEmail / currentDate <system-reminder> only on the first API call per conversation (re-fires after /clear). Default: OFF — the synthesized reminder is not persisted to the conversation log, so suppressing re-injection drops CLAUDE.md from the model context on every turn >= 2. Toggle ON only if the persistence side is also fixed.',
   },
 ] as const;
 
@@ -1030,7 +1030,7 @@ export const applyCustomization = async (
     'claudemd-context-once-per-conversation': {
       fn: c => writeClaudemdContextOncePerConversation(c),
       condition:
-        config.settings.misc?.claudemdContextOncePerConversation ?? true,
+        config.settings.misc?.claudemdContextOncePerConversation ?? false,
     },
   };
 

--- a/src/ui/components/MiscView.tsx
+++ b/src/ui/components/MiscView.tsx
@@ -88,7 +88,7 @@ export function MiscView({ onSubmit }: MiscViewProps) {
     maxEffortDefault: false,
     autoModeClassifierModel: 'default' as AutoModeClassifierModel,
     suppressDeferredTools: false,
-    claudemdContextOncePerConversation: true,
+    claudemdContextOncePerConversation: false,
   };
 
   const ensureMisc = () => {


### PR DESCRIPTION
## Workaround for users on the current published version

If you've already applied tweakcc-fixed and are hitting this, you don't need to wait for the PR to land. Open `~/.tweakcc/config.json`, find `settings.misc.claudemdContextOncePerConversation`, set it to `false`, then re-apply:

```bash
node ~/dev/tweakcc-fixed/dist/index.mjs --apply
# or if you installed via npm:
npx tweakcc-fixed@latest --apply
```

Restart any running `claude` session afterward. Verify by asking a fresh session, on turn 2, to quote something distinctive from your `~/.claude/CLAUDE.md` without using any tools. If it can recite it, the per-turn injection is back.

## Summary

The `claudemd-context-once-per-conversation` patch (currently default ON) silently drops `~/.claude/CLAUDE.md` (and `userEmail` / `currentDate`) from the model's context on every turn from turn 2 onward. The model only sees `claudeMd` on the very first API call of a conversation; for the rest of the conversation, every CLAUDE.md instruction is invisible.

This PR flips the default to `false` so users opt in instead of opting out. The patch code itself is left in place, so once the persistence side is fixed the default can be flipped back.

## Repro

1. Have non-empty `~/.claude/CLAUDE.md` with a distinctive rule (e.g. a "use single dash, not em-dash" line).
2. Apply `tweakcc-fixed` with the toggle at its current default (`true`).
3. Start a fresh `claude` session.
4. **Turn 1:** `hi`
5. **Turn 2:** `Without using any tools, quote the verbatim rule about dashes from my ~/.claude/CLAUDE.md.`

Observed: Claude reports it cannot see CLAUDE.md content and asks to Read the file.

Expected: Claude quotes the rule directly because the `<system-reminder>` containing `claudeMd` is injected per turn.

Flipping the toggle to `false` and re-applying restores expected behavior on turn 2+ in the same `cli.js` build.

## Root cause

`src/patches/systemReminders.ts:24-27` inserts `if(${msgsParam}.length>1) return ${msgsParam};` into Claude Code's `hY6(messages, userContext)` wrapper. `hY6` is the per-API-call builder that prepends a synthetic `<system-reminder>` containing `{claudeMd, userEmail, currentDate}` before the request goes out.

**Pristine `hY6` (CC 2.1.142):**

```js
function hY6(H,_){
  if(Object.entries(_).length===0) return H;
  return [j6({content:`<system-reminder>\nAs you answer the user's questions, you can use the following context:\n${Object.entries(_).map(([q,K])=>`# ${q}\n${K}`).join('\n')}\n\n      IMPORTANT: this context may or may not be relevant to your tasks. You should not respond to this context unless it is highly relevant to your task.\n</system-reminder>\n`,isMeta:!0}), ...H];
}
```

**Patched `hY6` (after `--apply`):**

```js
function hY6(H,_){
  if(Object.entries(_).length===0) return H;
  if(H.length>1) return H;          // <- the patch
  return [j6({...}), ...H];
}
```

The synthesized reminder message is **not persisted to the conversation log**. Claude Code writes only real user/assistant turns to `.jsonl`, then rebuilds the API message list from those turns each call, and re-runs `hY6` against the rebuilt list. So:

- **Turn 1:** `H = [user1]`, length 1, branch falls through, reminder prepended. Model sees `claudeMd` for this one call.
- **Turn 2:** `H = [user1, assistant1, user2]` reconstructed from the log (no synthetic message in there), length 3 > 1, early return. Anthropic's API receives turn 2 with no `claudeMd` anywhere. Turn 1's synthetic message is gone forever.
- **Turn N >= 2:** same.

The patch's stated intent (`src/patches/index.ts:484`: *"Inject the claudeMd / userEmail / currentDate <system-reminder> only on the first API call per conversation"*) needs a corresponding persistence step on the log-writer side. Without it, "once per conversation" in practice means "once, then never, and the model loses the context for the rest of the conversation."

## Why caching does not save it

Prompt caching only short-circuits identical message prefixes between calls. With the patch active, turn 2's prefix simply does not contain the synthetic reminder, so there is nothing to short-circuit to. The content was only in turn 1's request body and is discarded with the response.

## Verification

Side-by-side of pristine vs patched `cli.js` around the `hY6` definition shows only the `if(H.length>1)return H;` line differs. With `~/.tweakcc/config.json -> settings.misc.claudemdContextOncePerConversation: false` followed by `node dist/index.mjs --apply`, that single line is gone and per-turn injection resumes. Tested on CC 2.1.142, fresh session: turn 2 now correctly recalls CLAUDE.md content without tool use.

## Changes

- `src/defaultSettings.ts:725`: `true` -> `false`.
- `src/ui/components/MiscView.tsx:91`: same default in the UI's `defaultMisc`.
- `src/patches/index.ts:1033`: fallback `?? true` -> `?? false` for configs that don't have the key.
- `src/patches/index.ts:484`: patch description rewritten to document the breakage and the condition under which it would be safe to flip back to ON.

`pnpm test` passes (238 tests). Lint exit code is unchanged vs. `main` (pre-existing failures in `dist/` / `tools/`, none in `src/`).

## Alternatives considered

1. **Remove the patch entirely.** Cleaner: the per-turn injection costs only a few hundred tokens and the silent-loss failure mode is severe. Held off here to keep the diff minimal and not throw away the work; happy to follow up with a separate PR if you'd prefer removal.
2. **Salvage the design correctly.** Hook the message-log writer so turn 1's synthetic reminder becomes a real persisted message in the conversation history. Significantly more work, and this PR (or full removal) probably addresses the practical concern in the meantime.

Branch: `tenequm:fix/claudemd-context-default-off`.
