### PR TITLE
fix(systemPrompts): normalize CRLF prompt overrides

### DIFF
--- a/src/patches/systemPrompts.test.ts
+++ b/src/patches/systemPrompts.test.ts
@@ -166,6 +166,60 @@ describe('systemPrompts.ts', () => {
       expect(result.newContent).toBe('description:"Hello\\nWorld"');
     });
 
+    it('should convert CRLF line endings to \\n for double-quoted string literals (Windows)', async () => {
+      const mockPromptData = buildMockPromptData({
+        prompt: { content: 'Hello\r\nWorld' },
+        regex: 'Hello(?:\n|\\\\n)World',
+        getInterpolatedContent: () => 'Hello\r\nWorld',
+        pieces: ['Hello\r\nWorld'],
+      });
+
+      setupMocks(mockPromptData);
+
+      const cliContent = 'description:"Hello\\nWorld"';
+
+      const result = await applySystemPrompts(cliContent, '1.0.0', false);
+
+      expect(result.newContent).toBe('description:"Hello\\nWorld"');
+      expect(result.newContent).not.toMatch(/\r/);
+    });
+
+    it('should convert CRLF line endings to \\n for single-quoted string literals (Windows)', async () => {
+      const mockPromptData = buildMockPromptData({
+        prompt: { content: 'Hello\r\nWorld' },
+        regex: 'Hello(?:\n|\\\\n)World',
+        getInterpolatedContent: () => 'Hello\r\nWorld',
+        pieces: ['Hello\r\nWorld'],
+      });
+
+      setupMocks(mockPromptData);
+
+      const cliContent = "msg:'Hello\\nWorld'";
+
+      const result = await applySystemPrompts(cliContent, '1.0.0', false);
+
+      expect(result.newContent).toBe("msg:'Hello\\nWorld'");
+      expect(result.newContent).not.toMatch(/\r/);
+    });
+
+    it('should normalize CRLF to LF for backtick template literals (Windows)', async () => {
+      const mockPromptData = buildMockPromptData({
+        prompt: { content: 'Hello\r\nWorld' },
+        regex: 'Hello(?:\n|\\\\n)World',
+        getInterpolatedContent: () => 'Hello\r\nWorld',
+        pieces: ['Hello\r\nWorld'],
+      });
+
+      setupMocks(mockPromptData);
+
+      const cliContent = 'description:`Hello\nWorld`';
+
+      const result = await applySystemPrompts(cliContent, '1.0.0', false);
+
+      expect(result.newContent).toBe('description:`Hello\nWorld`');
+      expect(result.newContent).not.toMatch(/\r/);
+    });
+
     it('should keep actual newlines for backtick template literals', async () => {
       const mockPromptData = buildMockPromptData({
         prompt: { content: 'Hello\nWorld' },

--- a/src/patches/systemPrompts.ts
+++ b/src/patches/systemPrompts.ts
@@ -195,12 +195,13 @@ export const applySystemPrompts = async (
       }
 
       if (delimiter === '"') {
-        replacementContent = replacementContent.replace(/\n/g, '\\n');
+        replacementContent = replacementContent.replace(/\r\n|\r|\n/g, '\\n');
         replacementContent = escapeUnescapedChar(replacementContent, '"');
       } else if (delimiter === "'") {
-        replacementContent = replacementContent.replace(/\n/g, '\\n');
+        replacementContent = replacementContent.replace(/\r\n|\r|\n/g, '\\n');
         replacementContent = escapeUnescapedChar(replacementContent, "'");
       } else if (delimiter === '`') {
+        replacementContent = replacementContent.replace(/\r\n|\r/g, '\n');
         const { content: escaped, incomplete } =
           escapeDepthZeroBackticks(replacementContent);
         if (incomplete) {


### PR DESCRIPTION
## Summary

- Normalize CRLF/lone CR line endings before embedding system prompt overrides into JS string literals.
- Preserve LF-only behavior on macOS/Linux.
- Add Windows CRLF regression coverage for double-quoted, single-quoted, and backtick prompt contexts.

This targets the likely cause of skrabe/lobotomized-claude-code#3: Windows override files can contain CRLF, and the old quote-context escaping only replaced LF, leaving bare CR characters in patched JS.

## Testing

- `pnpm vitest run src/patches/systemPrompts.test.ts`
- `pnpm test`
- `pnpm lint`

## Windows validation requested

On Windows, after applying this branch:

```cmd
cd /d "%USERPROFILE%\dev\tweakcc-fixed"
git fetch origin fix/windows-crlf-system-prompts
git checkout fix/windows-crlf-system-prompts
pnpm install
pnpm build
node "%USERPROFILE%\dev\tweakcc-fixed\dist\index.mjs" --apply
node --check "%USERPROFILE%\.tweakcc\native-claudejs-patched.js"
claude --version
```