### PR TITLE
Draft: surviving-placeholder (orphan) report producer

### DIFF
--- a/tools/reportOrphans.mjs
+++ b/tools/reportOrphans.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// Surviving-placeholder (orphan) report — the apply-time companion to the
+// mis-bind audit. Where auditMisbinds.mjs checks placeholders the override DOES
+// bind (right name, wrong slot), this enumerates placeholders that bind to
+// NOTHING: a `${...}` whose leading identifier is not a known slot for its
+// prompt, so it survives `--apply` as a raw `${NAME}` into a live template
+// literal and fires `ReferenceError: NAME is not defined` at boot. That runtime-
+// orphan class is what boot-verify catches live (e.g. IS_TRUTHY_FN on 2.1.168/
+// .169); this tool surfaces the same set statically, as structured data, so a
+// downstream gate can map each finding to its ReferenceError signature without a
+// live install. auditMisbinds deliberately skips this set ("leak/uncomparable:
+// other gates cover it") — this is that other gate.
+//
+// Two things distinguish detection from a bare-`${NAME}` scan:
+//   1. It covers the EXPRESSION class, not just bare names. The crashing forms
+//      are interpolation expressions — `${!IS_TRUTHY_FN(PROCESS_OBJECT.env.X)&&..?`…`}`,
+//      `${ATTACHMENT_OBJECT.blockingError.command}`, `${ADDITIONAL_DREAM_GUIDANCE_FN()}`.
+//      The leading identifier of the expression is the one that must resolve in
+//      runtime scope, so that is what we extract. (auditMisbinds' `\$\{([A-Z]…)`
+//      regex matches only when the identifier is FLUSH against `${`, so it misses
+//      the leading-operator forms like `${!IS_TRUTHY_FN(…)` entirely.)
+//   2. Escaped `\${…}` is inert (the patcher emits it as a literal dollar-brace),
+//      so it is never an orphan and is not flagged.
+//
+// Known-slot set, per prompt: the prompt's own identifierMap values (the slots
+// the patcher can actually fill for that prompt). For an override whose id has no
+// counterpart in the prompts JSON (a tweakcc-own prompt), fall back to the UNION
+// of identifierMap values across every prompt — the conservative floor that still
+// flags names that are a slot NOWHERE (PROCESS_OBJECT, CRON_DURABLE_FLAG, …).
+// No ALL_CAPS grammar guessing: the slot vocabulary is taken only from the JSON.
+//
+// The union here intentionally mirrors `loadIdentifierMapUnion` in
+// src/systemPromptSync.ts (the apply path's skip-guard source). If this lands in
+// the apply path instead of as a standalone tool, it should call that directly
+// rather than re-deriving the union — see the PR for that redirect. Two things the
+// apply-path guard does NOT do today, which this adds: (1) it matches only the
+// bare `${NAME}` form (regex requires `}` flush after the name), so it misses the
+// expression class that actually boot-crashes; (2) it only SKIPS names that ARE
+// in the union — it never emits the surviving set that is absent from the union
+// (PROCESS_OBJECT) or per-prompt-orphaned (IS_TRUTHY_FN on a prompt that has no
+// such slot). That surviving set is what a downstream gate needs.
+//
+// Opt-in: this is a standalone tool. It writes a single JSON object to stdout and
+// touches nothing in the normal `--apply` path.
+//
+// Usage:
+//   node tools/reportOrphans.mjs [promptsJson] [overridesDir]
+// Defaults target the local showtime layout (same as auditMisbinds.mjs).
+//
+// Output (stdout, one JSON object):
+//   { "version": "2.1.x", "prompts": { "<promptId>": ["VAR", ...] } }
+// keyed per prompt id + variable, so the consumer maps each finding to a
+// `ReferenceError: <VAR> is not defined` signature. Empty `prompts` => no
+// surviving placeholders found. Exit code is always 0 (a report, not a gate);
+// the consumer decides what a non-empty set means.
+import fs from 'node:fs';
+import path from 'node:path';
+
+const VER = process.env.CC_VER || '2.1.168';
+const promptsJson = process.argv[2] || `data/prompts/prompts-${VER}.json`;
+const overridesDir =
+  process.argv[3] ||
+  `${process.env.HOME}/.tweakcc/lobotomized-claude-code/system-prompts-opus-4-8`;
+
+// --- pure helpers (version-independent; unit-tested in reportOrphans.test.mjs) ---
+
+// Extract the leading identifier of every unescaped `${...}` interpolation in a
+// body. The leading identifier is the first [A-Z][A-Z0-9_]+ token immediately
+// inside the braces, after any leading operators/whitespace (`!`, spaces) but
+// before any `(`, `.`, etc. — that is the name that must resolve in runtime scope
+// for the expression to evaluate. Returns names in source order (deduped by the
+// caller). Escaped `\${...}` is skipped via the lookbehind.
+export function extractLeadingIdentifiers(body) {
+  const out = [];
+  const open = /(?<!\\)\$\{/g;
+  let m;
+  while ((m = open.exec(body)) !== null) {
+    const rest = body.slice(m.index + 2);
+    // skip leading unary operators / whitespace, then require an UPPER-led ident.
+    const id = rest.match(/^[\s!~+\-]*([A-Z][A-Z0-9_]+)/);
+    if (id) out.push(id[1]);
+  }
+  return out;
+}
+
+// Build the set of known slot names for a prompts JSON: the union of every
+// prompt's identifierMap values. Also returns a per-id map of that prompt's own
+// slot names, so callers can prefer the precise per-prompt set.
+export function buildKnownSlots(promptsData) {
+  const union = new Set();
+  const byId = {};
+  for (const p of promptsData.prompts || []) {
+    const slots = new Set(Object.values(p.identifierMap || {}));
+    if (p.id) byId[p.id] = slots;
+    for (const v of slots) union.add(v);
+  }
+  return { union, byId };
+}
+
+// The surviving-placeholder set for one override body, given its prompt id and
+// the known-slot model. Per-prompt slots are authoritative when the id is in the
+// JSON; otherwise fall back to the union. A leading identifier not in that set is
+// a surviving placeholder (would be a ReferenceError at runtime).
+export function survivingPlaceholders(body, id, known) {
+  const slots = known.byId[id] || known.union;
+  const seen = new Set();
+  const orphans = [];
+  for (const name of extractLeadingIdentifiers(body)) {
+    if (slots.has(name) || seen.has(name)) continue;
+    seen.add(name);
+    orphans.push(name);
+  }
+  return orphans;
+}
+
+// --- driver (only runs when invoked as a script, not on import) ---
+
+function stripFrontmatter(raw) {
+  return (raw.match(/^<!--[\s\S]*?-->\n?([\s\S]*)$/) || [, raw])[1];
+}
+
+function main() {
+  const promptsData = JSON.parse(fs.readFileSync(promptsJson, 'utf8'));
+  const known = buildKnownSlots(promptsData);
+
+  const prompts = {};
+  for (const f of fs.readdirSync(overridesDir)) {
+    if (!f.endsWith('.md')) continue;
+    const id = f.slice(0, -3);
+    // inline-* overrides remap minified idents positionally, not by name — the
+    // identifierMap model does not apply to them (same carve-out as auditMisbinds).
+    if (id.startsWith('inline-')) continue;
+    const body = stripFrontmatter(
+      fs.readFileSync(path.join(overridesDir, f), 'utf8')
+    );
+    const orphans = survivingPlaceholders(body, id, known);
+    if (orphans.length) prompts[id] = orphans;
+  }
+
+  process.stdout.write(
+    JSON.stringify({ version: promptsData.version, prompts }, null, 2) + '\n'
+  );
+}
+
+// Run only as a script. Importing the helpers (e.g. from the test) is side-effect
+// free.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tools/reportOrphans.test.mjs
+++ b/tools/reportOrphans.test.mjs
@@ -1,0 +1,124 @@
+// Unit tests for the surviving-placeholder (orphan) producer's pure helpers.
+// Version-independent: no fixtures from a specific prompts JSON, no live install.
+import { describe, it, expect } from 'vitest';
+import {
+  extractLeadingIdentifiers,
+  buildKnownSlots,
+  survivingPlaceholders,
+} from './reportOrphans.mjs';
+
+describe('extractLeadingIdentifiers — covers the expression class, not just bare names', () => {
+  it('extracts a bare ${NAME}', () => {
+    expect(extractLeadingIdentifiers('${BARE_NAME}')).toEqual(['BARE_NAME']);
+  });
+
+  it('extracts the leading identifier of a function-call form ${FN()}', () => {
+    expect(extractLeadingIdentifiers('${ADDITIONAL_DREAM_GUIDANCE_FN()}')).toEqual([
+      'ADDITIONAL_DREAM_GUIDANCE_FN',
+    ]);
+  });
+
+  it('extracts the leading identifier of an object-member form ${OBJ.member}', () => {
+    expect(
+      extractLeadingIdentifiers('${ATTACHMENT_OBJECT.blockingError.command}')
+    ).toEqual(['ATTACHMENT_OBJECT']);
+  });
+
+  it('extracts the leading identifier past a leading unary operator (the boot-crash form)', () => {
+    // ${!IS_TRUTHY_FN(PROCESS_OBJECT.env.X)&&...?`…`:""} — IS_TRUTHY_FN is the name
+    // that must resolve. auditMisbinds' flush-against-`${` regex misses this form.
+    const body =
+      '${!IS_TRUTHY_FN(PROCESS_OBJECT.env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS)&&!IS_SUBAGENT_CONTEXT_FN()?`yes`:""}';
+    expect(extractLeadingIdentifiers(body)).toEqual(['IS_TRUTHY_FN']);
+  });
+
+  it('does NOT flag an escaped \\${...} (inert literal)', () => {
+    expect(extractLeadingIdentifiers('\\${ESCAPED_LITERAL}')).toEqual([]);
+    // mixed: only the unescaped one is extracted
+    expect(extractLeadingIdentifiers('\\${VERSION} and ${REAL_SLOT}')).toEqual([
+      'REAL_SLOT',
+    ]);
+  });
+
+  it('ignores a lowercase-led interpolation (legitimate inline JS, never a slot)', () => {
+    expect(extractLeadingIdentifiers('${someJsExpr.foo}')).toEqual([]);
+  });
+
+  it('returns identifiers in source order across multiple interpolations', () => {
+    expect(extractLeadingIdentifiers('a ${FIRST_VAR} b ${SECOND_VAR}')).toEqual([
+      'FIRST_VAR',
+      'SECOND_VAR',
+    ]);
+  });
+});
+
+describe('buildKnownSlots — union and per-prompt slot model from the prompts JSON', () => {
+  const data = {
+    version: '9.9.9',
+    prompts: [
+      { id: 'alpha', identifierMap: { 0: 'A_SLOT', 1: 'SHARED_SLOT' } },
+      { id: 'beta', identifierMap: { 0: 'B_SLOT', 1: 'SHARED_SLOT' } },
+      { id: 'no-map' },
+    ],
+  };
+
+  it('union is every identifierMap value across all prompts', () => {
+    const { union } = buildKnownSlots(data);
+    expect([...union].sort()).toEqual(['A_SLOT', 'B_SLOT', 'SHARED_SLOT']);
+  });
+
+  it('byId carries each prompt’s own slots only', () => {
+    const { byId } = buildKnownSlots(data);
+    expect([...byId.alpha].sort()).toEqual(['A_SLOT', 'SHARED_SLOT']);
+    expect([...byId.beta].sort()).toEqual(['B_SLOT', 'SHARED_SLOT']);
+    expect([...byId['no-map']]).toEqual([]);
+  });
+});
+
+describe('survivingPlaceholders — per-prompt orphan logic with union fallback', () => {
+  const known = buildKnownSlots({
+    version: '9.9.9',
+    prompts: [
+      { id: 'alpha', identifierMap: { 0: 'A_SLOT', 1: 'SHARED_SLOT' } },
+      { id: 'beta', identifierMap: { 0: 'B_SLOT' } },
+    ],
+  });
+
+  it('flags a name that is not a slot for THIS prompt even if it is a slot elsewhere', () => {
+    // B_SLOT is a valid slot for beta, but an orphan for alpha — the precise
+    // per-prompt signal (the IS_TRUTHY_FN-on-agent-usage-notes #26 case).
+    expect(survivingPlaceholders('${A_SLOT} ${B_SLOT}', 'alpha', known)).toEqual([
+      'B_SLOT',
+    ]);
+  });
+
+  it('does not flag a name bound for this prompt', () => {
+    expect(survivingPlaceholders('${A_SLOT} ${SHARED_SLOT}', 'alpha', known)).toEqual(
+      []
+    );
+  });
+
+  it('flags a name that is a slot NOWHERE', () => {
+    expect(survivingPlaceholders('${PROCESS_OBJECT.env.X}', 'alpha', known)).toEqual([
+      'PROCESS_OBJECT',
+    ]);
+  });
+
+  it('falls back to the union for an override id absent from the JSON', () => {
+    // tweakcc-own prompt: no per-prompt map, so any in-union name is accepted and
+    // only a nowhere-name is flagged.
+    expect(
+      survivingPlaceholders('${A_SLOT} ${UNKNOWN_GHOST}', 'tweakcc-own', known)
+    ).toEqual(['UNKNOWN_GHOST']);
+  });
+
+  it('dedupes repeated orphans', () => {
+    expect(
+      survivingPlaceholders('${GHOST} and again ${GHOST}', 'alpha', known)
+    ).toEqual(['GHOST']);
+  });
+
+  it('does not flag escaped literals', () => {
+    expect(survivingPlaceholders('\\${GHOST}', 'alpha', known)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Draft proposal — surviving-placeholder (orphan) report producer

**What it does.** Adds `tools/reportOrphans.mjs`, an opt-in producer that enumerates the *apply-time surviving-placeholder set*: a `${...}` whose leading identifier binds to no slot for its prompt, so it survives `--apply` as a raw `${NAME}` into a live template literal and faults at boot (`ReferenceError: NAME is not defined`). It is the structured-data companion to `auditMisbinds.mjs` — that tool checks placeholders that DO bind (right name, wrong slot) and deliberately skips this set ("leak/uncomparable: other gates cover it"); this is meant to be that other gate.

It writes one JSON object to stdout and touches nothing in the normal `--apply` path:

```
{ "version": "2.1.x", "prompts": { "<promptId>": ["VAR", ...] } }
```

keyed per prompt id and variable, so a downstream consumer can map each finding to its `ReferenceError: <VAR> is not defined` signature without a live install.

**Two things it does beyond a bare scan** (and beyond your existing apply-path skip-guard in `src/patches/systemPrompts.ts`):
1. **Covers the expression class, not just bare names.** The crashing forms are interpolation expressions — `${!IS_TRUTHY_FN(PROCESS_OBJECT.env.X)&&..?` ... `}`, `${OBJECT.member}`, `${FN()}`. It extracts the *leading* identifier of each expression (the name evaluated first, hence the one that appears in the ReferenceError). Your apply-path guard's regex requires the closing brace flush after the name, so it matches only the bare `${NAME}` form and never sees these.
2. **Per-prompt precision with a union fallback.** The known-slot set is the prompt's own `identifierMap` values; for a tweakcc-own id absent from the prompts JSON it falls back to the union (which mirrors your `loadIdentifierMapUnion`). The per-prompt set is what catches `IS_TRUTHY_FN` on a prompt that has no such slot — the union alone would not, since `IS_TRUTHY_FN` is a valid slot on another prompt. Escaped literals are inert and not flagged.

**It's a draft proposal — your call on the final shape and home.** I built it as a standalone `tools/` helper (sibling to `auditMisbinds.mjs`, version-independent) because that was the most reviewable surface to show the idea. But the home is entirely yours to pick:
- fold it into the apply path in `systemPrompts.ts` (the natural deep home — it already has the union and the per-prompt resolution in hand, so this could reuse `loadIdentifierMapUnion` directly instead of re-deriving the union),
- make it a field on `driver.mjs report`,
- or extend `auditMisbinds` output to emit the set it currently skips.

Happy to rework it into whichever fits — or to drop it entirely if keeping the boot-verify backstop plus the existing count is the answer you prefer.

**The cost it puts on you.** One new helper unit you would maintain (the leading-identifier extraction + the per-prompt/union orphan logic). It is opt-in — a separate tool that emits JSON to stdout — so there is zero impact on the normal `--apply` flow, and nothing in your release path has to call it. The helpers are version-independent and unit-tested (`tools/reportOrphans.test.mjs`, 15 cases: bare name, `_FN(...)`, `_OBJECT.member`, the leading-operator boot-crash form, escaped `\${...}` not flagged, per-prompt vs union). The mis-bind audit and the four-zeros bar are untouched.

**No merge pressure.** This is a prepared draft for your consideration, not a request to land. Keeping it as the placeholder count plus boot-verify is a perfectly good answer.

**Why we want it (the consumer side).** This is the *producer* for our integration gate's orphan-report consumer. Today the consumer falls back to a boot-verify-derived proxy because no tool emits the surviving *set* keyed per prompt + variable. A real producer lets the gate map each finding to its exact ReferenceError signature statically.

---

### Agreement with the recorded boot-verify evidence

Run against our overrides set with the 2.1.169 prompts JSON, the producer keys the prompt that boot-crashed on our 2.1.169 gate run exactly as boot-verify reported it:

```
$ node tools/reportOrphans.mjs data/prompts/prompts-2.1.169.json <overrides-dir>
...
  "tool-description-agent-usage-notes": [ "IS_TRUTHY_FN" ],
...
```

That override is pinned at an older ccVersion and interpolates `${!IS_TRUTHY_FN(PROCESS_OBJECT.env...)&&..?` ... `}`; `IS_TRUTHY_FN` is not a slot for *that* prompt in 2.1.169, so it survives apply and faults — matching the live `ReferenceError: IS_TRUTHY_FN is not defined` we recorded. (Leading-identifier note: it reports `IS_TRUTHY_FN`, not the nested `PROCESS_OBJECT`, because that is the name evaluated first and the one in the actual ReferenceError.)

### Verification

- `tools/reportOrphans.test.mjs` — 15 unit tests, all pass.
- Full suite: `vitest run` — 365 passed, 5 skipped (29 files); no regression. `tsc --noEmit` and `eslint src` clean.
- `auditMisbinds` still exits 0 against our set (the change is purely additive; your slot logic is untouched).
- **Left for you:** a real-install boot-verify on your machine — confirming that an override flagged by this producer is the one that crashes, and that a clean set produces an empty `prompts` object. The agreement above is against our recorded boot-verify set; it is sufficient for a draft but is not a substitute for your own live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
