### PR TITLE
fix(systemPromptSync): extend shadows: to built-in reminder overrides (2.1.173 driver-check)

### DIFF
--- a/src/patches/systemReminderOverrides.ts
+++ b/src/patches/systemReminderOverrides.ts
@@ -760,9 +760,16 @@ const EDITED_TEXT_FILE_INJECTION: ReminderInjection = {
   name: 'Edited-text-file post-edit note',
   description:
     'Conditional note injected after a file is edited (by user or linter). Empty .md body = silent edits.',
-  // Splices the shared ternary-branch prefix the budget-exceeded named prompt
-  // anchors on, so that named prompt cannot match a second time.
-  shadows: ['system-reminder-file-modification-detected-budget-exceeded'],
+  // Consumes the whole ternary, including the branch the externally-modified
+  // named prompt anchors on. Both named prompts must be shadowed: the
+  // budget-exceeded one matches the spliced prefix a second time, and
+  // file-modified-externally only matches a stock install because this
+  // registry's defaultBody happens to mirror the pristine branch text — once a
+  // user customizes edited-text-file.md, its anchor vanishes too.
+  shadows: [
+    'system-reminder-file-modification-detected-budget-exceeded',
+    'system-reminder-file-modified-externally',
+  ],
   placeholders: {
     filename: '${H.filename}',
     snippet: '${H.snippet}',

--- a/src/patches/systemReminderOverrides.ts
+++ b/src/patches/systemReminderOverrides.ts
@@ -25,6 +25,11 @@ export interface ReminderInjection {
   description: string;
   placeholders: Record<string, string>;
   defaultBody: string;
+  // Named-prompt ids this built-in override consumes during --apply: it
+  // splices the shared cli.js region the named prompt would otherwise anchor
+  // on, so the named-prompt pass cannot match a second time. loadShadowSet
+  // unions these into the shadow set (alongside runtime .md `shadows:`).
+  shadows?: string[];
   apply: (
     content: string,
     body: string,
@@ -755,6 +760,9 @@ const EDITED_TEXT_FILE_INJECTION: ReminderInjection = {
   name: 'Edited-text-file post-edit note',
   description:
     'Conditional note injected after a file is edited (by user or linter). Empty .md body = silent edits.',
+  // Splices the shared ternary-branch prefix the budget-exceeded named prompt
+  // anchors on, so that named prompt cannot match a second time.
+  shadows: ['system-reminder-file-modification-detected-budget-exceeded'],
   placeholders: {
     filename: '${H.filename}',
     snippet: '${H.snippet}',
@@ -1129,6 +1137,9 @@ const TASK_LIST_REMINDER_INJECTION: ReminderInjection = {
   name: 'Task-list status reminder',
   description:
     'Fires every turn while TaskList has entries. Wraps the current task list with reminder text about using TaskCreate. Empty .md = suppress entirely.',
+  // Rewrites the task-reminder region to new phrasing before the named prompt
+  // (anchored on the old phrasing) runs, leaving it unmatchable.
+  shadows: ['system-reminder-task-tools-reminder'],
   placeholders: {
     tasks: '${q}',
   },

--- a/src/systemPromptSync.ts
+++ b/src/systemPromptSync.ts
@@ -12,6 +12,7 @@ import {
 } from './systemPromptHashIndex';
 import chalk from 'chalk';
 import { SYSTEM_PROMPTS_DIR, SYSTEM_REMINDERS_DIR } from './config';
+import { REMINDER_REGISTRY } from './patches/systemReminderOverrides';
 import { debug } from './utils';
 
 /**
@@ -53,6 +54,16 @@ export const loadShadowSet = async (): Promise<Set<string>> => {
         for (const id of shadows) {
           if (typeof id === 'string' && id) set.add(id);
         }
+      }
+    }
+  }
+  // Built-in reminder overrides declare their named-prompt collisions inline
+  // (ReminderInjection.shadows): they splice a shared cli.js region a later
+  // named prompt anchors on, so the named-prompt pass cannot match again.
+  for (const injection of REMINDER_REGISTRY) {
+    if (Array.isArray(injection.shadows)) {
+      for (const id of injection.shadows) {
+        if (typeof id === 'string' && id) set.add(id);
       }
     }
   }


### PR DESCRIPTION
**Draft / suggestion — prepared for you to pull ready, not a merge request.** This touches your `ReminderInjection` interface and `loadShadowSet` reader, so it's your architecture and your call to take, adapt, or reject.

## What it does

At CC 2.1.173, two built-in `ReminderInjection` overrides splice cli.js regions that a *later* named-prompt pass anchors on, so `--apply` reports `Could not find` twice and `driver.mjs check` fails the four-zeros verdict:

- `system-reminder-file-modification-detected-budget-exceeded` — `EDITED_TEXT_FILE_INJECTION` rewrites the shared ternary-branch prefix (`Note: ${H.filename} was modified… already aware.`), consuming the budget branch before the named prompt runs.
- `system-reminder-task-tools-reminder` — `TASK_LIST_REMINDER_INJECTION` rewrites the task-reminder region to new phrasing before the named prompt (anchored on the old phrasing) runs.

These are the exact collisions your `shadows:` mechanism was built for — but `loadShadowSet` only reads `<!-- shadows: -->` frontmatter from runtime `.md` overlays, so it can't reach a collision declared by a built-in TS override. This **extends your own mechanism** to cover them:

1. Optional `shadows?: string[]` on the `ReminderInjection` interface.
2. The two collisions declared inline on `EDITED_TEXT_FILE_INJECTION` and `TASK_LIST_REMINDER_INJECTION`.
3. `loadShadowSet` unions every `REMINDER_REGISTRY` entry's `shadows` into the set, alongside its existing `.md` scan — so `loadSystemPromptsWithRegex` skips the two ids exactly as it does an `.md`-declared shadow today.

No coverage loss: those cli.js regions are still patched, via the reminder-override channel; the named-prompt pass simply no longer expects a second independent match.

## Verification (against pristine 2.1.173)

Reproduced the way the gate does — pristine strings extracted from the freshly-installed **native** 2.1.173 binary, **stock** install, isolated override dir (all 394 named prompts auto-create + apply):

- **Before** (your `3c29532`, this fix absent): `--apply` → `Could not find: 2` (the two prompts above).
- **After** (this branch): `Could not find: 0`, exit 0. `failed to find: 0`, `Conflicts detected: 0`, `✗ failures: 0`, "Customizations applied successfully!".
- Diff of the two apply logs: the **only** change is the two `Could not find` lines disappearing — no other prompt regressed.
- Install restored to stock after; never diagnosed anchors from a patched tree.

This clears the `driver-check` leg of the four-zeros verdict at 2.1.173.

## Cost on you

One optional field carried on the `ReminderInjection` interface, plus the `loadShadowSet` reader unioning the registry. Both are version-independent (no per-bump snapshot to regenerate). Minimal and idiomatic to your existing `shadows:` design.

Finding tracked at https://github.com/dividedby/tweakcc-maint/issues/230 (Issues are disabled here, so this draft PR is the suggestion vehicle).
