### PR TITLE
fix(systemReminderOverrides): discover wrapper past a comma-expression (memory_update)

### DIFF
--- a/src/patches/systemReminderOverrides.test.ts
+++ b/src/patches/systemReminderOverrides.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { REMINDER_REGISTRY } from './systemReminderOverrides';
+
+const memoryUpdate = REMINDER_REGISTRY.find(r => r.id === 'memory-update')!;
+
+// Memory_update case shaped like CC 2.1.177's cli.js: the wrapper call is
+// preceded by a comma-expression (`return K.push(rm6),HT([U6(...`), unlike the
+// other reminder cases which emit `return X([Y(...` directly. discoverWrappers
+// used to anchor on `return X([` and so missed this, falling back to the stale
+// hardcoded o5/j6 and crashing at runtime with "j6 is not a function".
+const MOCK_COMMA_EMIT =
+  'case"memory_update":{let K=[`${OSO[H.source]} updated your memory directory: ${H.summary}`];' +
+  'return K.push(rm6),HT([U6({content:K.join(`\\n`),isMeta:!0})])}';
+
+// Same case with the wrapper emitted directly after `return` (other builds).
+const MOCK_DIRECT_EMIT =
+  'case"memory_update":{let K=`updated your memory directory`;' +
+  'return HT([U6({content:K,isMeta:!0})])}';
+
+describe('memory-update reminder wrapper discovery', () => {
+  it('reads the real wrapper/ctor past a comma-expression, not the o5/j6 fallback', () => {
+    const result = memoryUpdate.apply(MOCK_COMMA_EMIT, 'memory changed', false);
+    expect(result).not.toBeNull();
+    expect(result).toContain('HT([U6({content:');
+    expect(result).not.toContain('o5([j6(');
+  });
+
+  it('still reads a wrapper emitted directly after return', () => {
+    const result = memoryUpdate.apply(
+      MOCK_DIRECT_EMIT,
+      'memory changed',
+      false
+    );
+    expect(result).not.toBeNull();
+    expect(result).toContain('HT([U6({content:');
+  });
+});

--- a/src/patches/systemReminderOverrides.ts
+++ b/src/patches/systemReminderOverrides.ts
@@ -131,13 +131,16 @@ const findCaseBody = (
 };
 
 // Pull the array-wrapper / message-constructor minified identifiers from an
-// existing case body. Pattern: `return X([Y({content:` — Mac builds give o5/j6,
-// Linux builds give o_/M8. Prefer the last match (case bodies sometimes call
-// the wrappers earlier with different ids for unrelated subcases).
+// existing case body. Pattern: `return …X([Y({content:` — Mac builds give o5/j6,
+// Linux builds give o_/M8. The wrapper isn't always the first thing after
+// `return`: the memory_update case prepends a comma-expression
+// (`return K.push(rm6),HT([U6({content:`), so skip any non-`;` chars before the
+// match. Prefer the last match (case bodies sometimes call the wrappers earlier
+// with different ids for unrelated subcases).
 const discoverWrappers = (
   caseBody: string
 ): { arrayWrap: string; msgCtor: string } => {
-  const re = /return\s+([$\w]+)\(\[([$\w]+)\(\{content:/g;
+  const re = /return\s+[^;]*?([$\w]+)\(\[([$\w]+)\(\{content:/g;
   let last: RegExpExecArray | null = null;
   let m: RegExpExecArray | null;
   while ((m = re.exec(caseBody)) !== null) last = m;


### PR DESCRIPTION
## What's wrong

The `memory_update` reminder crashes Claude Code at runtime: `j6 is not a function (j6 is an instance of Object)`. It only fires once a memory-update event happens, e.g. after dream/auto-dream consolidation writes memory, so it stays hidden the rest of the time. `--apply` reports success and `claude --version` works, which is why it ships unnoticed unless you actually run with consolidation on.

I hit it on macOS arm64 and someone else hit the same thing on WSL, both on CC 2.1.175 and 2.1.177. Patching a fresh pristine binary reproduces it every time, so it isn't a double-patch.

## Why

`discoverWrappers` looks for `return X([Y({content:` and only matches when the wrapper comes straight after `return`. The pristine `memory_update` case puts a comma-expression in front:

```js
return K.push(rm6),HT([U6({content:K.join(`\n`),isMeta:!0})])
```

So the regex doesn't match, `discoverWrappers` returns the hardcoded `{o5, j6}`, and the patched case calls `j6({...})`. On current builds `j6` is an unrelated object, not the message constructor, so it throws. The other reminder cases emit `return X([Y(` directly, match fine, and get the real constructor (`U6`); that's why only `memory_update` breaks.

## Fix

Let the matcher skip anything up to the next `;` before the wrapper:

```diff
- const re = /return\s+([$\w]+)\(\[([$\w]+)\(\{content:/g;
+ const re = /return\s+[^;]*?([$\w]+)\(\[([$\w]+)\(\{content:/g;
```

Cases that emit the wrapper right after `return` still match with the lazy part empty, so nothing else changes.

## Testing

Added a regression test in `systemReminderOverrides.test.ts` covering the comma-expression and direct-emit shapes. Full suite passes (34 files, 389 tests). On a real 2.1.177 binary the patched case comes out as `return HT([U6({content:...` and `claude` starts clean.
