### PR TITLE
fix(scripts): generate identifierUnion before lint (CI tsc TS2307)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build:dev": "node tools/generateIdentifierUnion.mjs && tsdown --dts src/index.tsx src/lib/index.ts",
     "watch": "tsdown --watch --dts src/index.tsx src/lib/index.ts",
     "start": "node dist/index.mjs",
+    "prelint": "node tools/generateIdentifierUnion.mjs",
     "lint": "tsc --noEmit && eslint src",
     "test": "vitest run",
     "test:dev": "vitest",

--- a/src/patches/systemReminderOverrides.test.ts
+++ b/src/patches/systemReminderOverrides.test.ts
@@ -36,7 +36,9 @@ describe('memory-update reminder wrapper discovery', () => {
   });
 });
 
-const taskNotif = REMINDER_REGISTRY.find(r => r.id === 'task-notification-framing')!;
+const taskNotif = REMINDER_REGISTRY.find(
+  r => r.id === 'task-notification-framing'
+)!;
 
 const NOTIF_BODY =
   '[SYSTEM NOTIFICATION - NOT USER INPUT]\n' +


### PR DESCRIPTION
## What's wrong

CI's lint job has failed on every push to `main` for the last few days:

```
src/systemPromptSync.ts(131,32): error TS2307: Cannot find module './generated/identifierUnion.js'
```

## Why

`src/generated/identifierUnion.ts` is generated by `tools/generateIdentifierUnion.mjs` at build time and is gitignored. `build` and `pretest` run the generator first, so the build and the test job are fine. `lint` (`tsc --noEmit && eslint src`) doesn't, so when CI runs `pnpm lint` the file isn't there yet and `tsc` can't resolve the dynamic import's type in `systemPromptSync.ts`. Release & Publish stays green because `prepublishOnly` runs `build`.

## Fix

Add a `prelint` hook that runs the generator, the same way `pretest` already does:

```diff
+ "prelint": "node tools/generateIdentifierUnion.mjs",
  "lint": "tsc --noEmit && eslint src",
```

## Also in this PR

With lint passing, the job reaches the `prettier --check src` step, which had been unreachable while lint was red. It flagged `src/patches/systemReminderOverrides.test.ts`: the `task-notification-framing` test added after #13 had a line over the print width. Wrapped it with prettier 3.6.2 so the format step passes too. Second commit, formatting only.

## Testing

Reproduced the `TS2307` by running `tsc` with `src/generated` removed. With the hook, `npm run lint` regenerates `identifierUnion.ts` and then `tsc` and `eslint` pass (exit 0, 0 TS errors). `prettier --check src` is clean, and the full suite is green (36 files, 427 passed).
