### PR TITLE
fix(patches): \uXXXX-escape injected non-ASCII to fix mojibake on Bun-compiled CC

### DIFF
--- a/src/patches/patchesAppliedIndication.ts
+++ b/src/patches/patchesAppliedIndication.ts
@@ -287,12 +287,12 @@ const applyIndicatorPatchesListPatch = (
     `,${reactVar}.createElement(${boxComponent}, { flexDirection: "column" },`
   );
   lines.push(
-    `${reactVar}.createElement(${boxComponent}, null, ${reactVar}.createElement(${textComponent}, {color: "success", bold: true}, "┃ "), ${reactVar}.createElement(${textComponent}, {color: "success", bold: true}, "✓ tweakcc-fixed patches are applied")),`
+    `${reactVar}.createElement(${boxComponent}, null, ${reactVar}.createElement(${textComponent}, {color: "success", bold: true}, "\\u2503 "), ${reactVar}.createElement(${textComponent}, {color: "success", bold: true}, "\\u2713 tweakcc-fixed patches are applied")),`
   );
   for (let item of patchesApplies) {
     item = item.replace('CHALK_VAR', chalkVar);
     lines.push(
-      `${reactVar}.createElement(${boxComponent}, null, ${reactVar}.createElement(${textComponent}, {color: "success", bold: true}, "┃ "), ${reactVar}.createElement(${textComponent}, {dimColor: true}, \`  * ${item}\`)),`
+      `${reactVar}.createElement(${boxComponent}, null, ${reactVar}.createElement(${textComponent}, {color: "success", bold: true}, "\\u2503 "), ${reactVar}.createElement(${textComponent}, {dimColor: true}, \`  * ${item}\`)),`
     );
   }
   lines.push('),');
@@ -572,12 +572,12 @@ export const writePatchesAppliedIndication = (
         `,${reactVar}.createElement(${boxComponent}, { flexDirection: "column" },`
       );
       lines.push(
-        `${reactVar}.createElement(${boxComponent}, null, ${reactVar}.createElement(${textComponent}, {color: "success", bold: true}, "┃ "), ${reactVar}.createElement(${textComponent}, {color: "success", bold: true}, "✓ tweakcc-fixed patches are applied")),`
+        `${reactVar}.createElement(${boxComponent}, null, ${reactVar}.createElement(${textComponent}, {color: "success", bold: true}, "\\u2503 "), ${reactVar}.createElement(${textComponent}, {color: "success", bold: true}, "\\u2713 tweakcc-fixed patches are applied")),`
       );
       for (let item of patchesApplies) {
         item = item.replace('CHALK_VAR', chalkVar);
         lines.push(
-          `${reactVar}.createElement(${boxComponent}, null, ${reactVar}.createElement(${textComponent}, {color: "success", bold: true}, "┃ "), ${reactVar}.createElement(${textComponent}, {dimColor: true}, \`  * ${item}\`)),`
+          `${reactVar}.createElement(${boxComponent}, null, ${reactVar}.createElement(${textComponent}, {color: "success", bold: true}, "\\u2503 "), ${reactVar}.createElement(${textComponent}, {dimColor: true}, \`  * ${item}\`)),`
         );
       }
       lines.push('),');

--- a/src/patches/thinkerFormat.test.ts
+++ b/src/patches/thinkerFormat.test.ts
@@ -39,7 +39,7 @@ describe('writeThinkerFormat', () => {
 
   it('keeps surrounding format text and substitutes the verb expr in the middle', () => {
     const out = writeThinkerFormat(FIXTURE_LATEST, '✻ {} now…')!;
-    expect(out).toContain('N7=`✻ ${Q9??C2?.activeForm??L4} now…`');
+    expect(out).toContain('N7=`\\u273b ${Q9??C2?.activeForm??L4} now\\u2026`');
   });
 
   it('handles the isIdle/spinnerVerb conditional shape via the NEW anchor', () => {

--- a/src/patches/thinkerFormat.ts
+++ b/src/patches/thinkerFormat.ts
@@ -1,6 +1,7 @@
 // Please see the note about writing patches in ./index
 
 import { LocationResult, showDiff } from './index';
+import { escapeNonAscii } from '../utils';
 
 const getThinkerFormatLocation = (oldFile: string): LocationResult | null => {
   // Older CC shape: spinnerTip + overrideMessage adjacent in one destructure.
@@ -144,10 +145,15 @@ export const writeThinkerFormat = (
   // Escape for the backtick template literal below: `\` and backtick prevent
   // corruption, and `${` prevents a user/remote format from injecting an
   // executable expression (cf. F-84). The `{}`→`${expr}` splice is added after.
-  const serializedFormat = format
-    .replace(/\\/g, '\\\\')
-    .replace(/`/g, '\\`')
-    .replace(/\$\{/g, '\\${');
+  // Run escapeNonAscii LAST: it only introduces `\uXXXX` (single-backslash)
+  // sequences, which the backslash-doubling above must not touch. Without it a
+  // raw "…" in the format mojibakes against CC's Latin-1 module storage.
+  const serializedFormat = escapeNonAscii(
+    format
+      .replace(/\\/g, '\\\\')
+      .replace(/`/g, '\\`')
+      .replace(/\$\{/g, '\\${')
+  );
   const curExpr = fmtLocation.identifiers?.[0];
   const curFmt =
     '`' + serializedFormat.replace(/\{\}/g, '${' + curExpr + '}') + '`';

--- a/src/patches/thinkerSymbolChars.ts
+++ b/src/patches/thinkerSymbolChars.ts
@@ -1,6 +1,7 @@
 // Please see the note about writing patches in ./index
 
 import { LocationResult, showDiff } from './index';
+import { escapeNonAscii } from '../utils';
 
 export const writeThinkerSymbolChars = (
   oldFile: string,
@@ -25,7 +26,10 @@ export const writeThinkerSymbolChars = (
     return null;
   }
 
-  const symbolsJson = JSON.stringify(symbols);
+  // Emit the symbols as `\uXXXX`-escaped ASCII: CC's cli.js module is stored in
+  // the Bun binary as Latin-1, so raw multibyte UTF-8 spliced in here would be
+  // read back byte-per-char at runtime (mojibake). See escapeNonAscii.
+  const symbolsJson = escapeNonAscii(JSON.stringify(symbols));
 
   // Sort locations by start index in descending order to apply from end to beginning.
   const sortedLocations = locations.sort((a, b) => b.startIndex - a.startIndex);

--- a/src/patches/thinkingVerbs.ts
+++ b/src/patches/thinkingVerbs.ts
@@ -1,6 +1,7 @@
 // Please see the note about writing patches in ./index
 
 import { showDiff } from './index';
+import { escapeNonAscii } from '../utils';
 
 /**
  * Replaces the thinker verbs array (e.g., ["Accomplishing","Actioning",...])
@@ -45,7 +46,9 @@ const patchPresentTenseVerbs = (
     return null;
   }
 
-  const replacement = JSON.stringify(verbs);
+  // `\uXXXX`-escape non-ASCII (e.g. "Flambéing") so it survives CC's Latin-1
+  // module storage instead of mojibaking at runtime. See escapeNonAscii.
+  const replacement = escapeNonAscii(JSON.stringify(verbs));
 
   const startIndex = match.index;
   const endIndex = startIndex + match[0].length;
@@ -82,7 +85,7 @@ const patchPastTenseVerbs = (file: string, verbs: string[]): string | null => {
 
   // Convert verbs from "ing" to "ed"
   const pastTenseVerbs = verbs.map(verb => verb.replace(/ing$/, 'ed'));
-  const replacement = JSON.stringify(pastTenseVerbs);
+  const replacement = escapeNonAscii(JSON.stringify(pastTenseVerbs));
 
   const startIndex = match.index;
   const endIndex = startIndex + match[0].length;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,48 @@
 import { describe, it, expect } from 'vitest';
-import { readResponseTextCapped, MAX_FETCH_BYTES } from './utils';
+import {
+  readResponseTextCapped,
+  MAX_FETCH_BYTES,
+  escapeNonAscii,
+} from './utils';
+
+describe('escapeNonAscii', () => {
+  // Keep backslashes out of string literals (via fromCharCode) so these
+  // assertions are unambiguous about the exact escaped bytes produced.
+  const BS = String.fromCharCode(92); // a single backslash
+
+  it('leaves ASCII untouched, including pre-existing unicode escapes', () => {
+    const s = 'plain ascii * 123 ' + BS + 'u2500';
+    expect(escapeNonAscii(s)).toBe(s);
+  });
+
+  it('escapes the mojibake-causing BMP glyphs', () => {
+    // U+2503 ┃, U+2713 ✓, U+273B ✻, U+2026 …, U+00E9 é
+    const input = String.fromCharCode(0x2503, 0x2713, 0x273b, 0x2026, 0xe9);
+    const expected =
+      BS + 'u2503' + BS + 'u2713' + BS + 'u273b' + BS + 'u2026' + BS + 'u00e9';
+    expect(escapeNonAscii(input)).toBe(expected);
+  });
+
+  it('escapes each surrogate half of an astral codepoint', () => {
+    expect(escapeNonAscii(String.fromCodePoint(0x1f600))).toBe(
+      BS + 'ud83d' + BS + 'ude00'
+    );
+  });
+
+  it('produces pure ASCII that parses back to the original string', () => {
+    const original =
+      'spinner ' +
+      String.fromCharCode(0x273b) +
+      ' done' +
+      String.fromCharCode(0x2026) +
+      ' caf' +
+      String.fromCharCode(0xe9);
+    const out = escapeNonAscii(original);
+    // eslint-disable-next-line no-control-regex
+    expect(/^[\x00-\x7f]*$/.test(out)).toBe(true);
+    expect(JSON.parse('"' + out + '"')).toBe(original);
+  });
+});
 
 describe('readResponseTextCapped', () => {
   it('returns the body when it is under the cap', async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,6 +43,28 @@ export const verbose = (message: any, ...optionalParams: any[]) => {
   }
 };
 
+/**
+ * Rewrite every non-ASCII (>= U+0080) code unit as a `\uXXXX` escape so the
+ * result is pure ASCII while parsing back to the identical JS string.
+ *
+ * Claude Code ships as a Bun standalone binary whose `cli.js` module is stored
+ * with esbuild's `charset=ascii` output — i.e. all non-ASCII is already emitted
+ * as `\uXXXX` escapes, so the module's source bytes are pure ASCII and Bun keeps
+ * them as a Latin-1 (1 byte/char) string. Any *raw* multibyte UTF-8 we splice
+ * into that source is therefore read back one byte per char at runtime, turning
+ * e.g. `┃` (E2 94 83) into `â` + two control chars (classic mojibake).
+ *
+ * Apply this to any non-ASCII string value — or to `JSON.stringify(...)` output
+ * — before embedding it into the patched source. It is safe to run over
+ * JSON.stringify output and over freshly-built string/template-literal contents
+ * because a raw non-ASCII char is never preceded there by a lone backslash.
+ */
+export const escapeNonAscii = (s: string): string =>
+  s.replace(
+    /[\u0080-\uffff]/g,
+    c => '\\u' + c.charCodeAt(0).toString(16).padStart(4, '0')
+  );
+
 export function getCurrentClaudeCodeTheme(): string {
   try {
     const ccConfigPath = path.join(os.homedir(), '.claude.json');


### PR DESCRIPTION
## Problem

Injected non-ASCII glyphs render as mojibake at runtime on Bun-compiled Claude Code. The "patches applied" startup notice bar/check shows as `â`, and a customized spinner (e.g. `✶`) shows as `â¶`.

## Root cause

Claude Code ships as a Bun standalone binary whose `cli.js` module is stored with esbuild's `charset=ascii` output — every non-ASCII char is emitted as a `\uXXXX` escape, so the module's source bytes are pure ASCII and Bun keeps the source as a **Latin-1 (1 byte/char)** string.

When a patch splices **raw** multibyte UTF-8 into that source, Bun reads it back one byte per char at runtime:

- `┃` (`E2 94 83`) → `â` + two control chars
- `✶` (`E2 9C B6`) → `â` + control + `¶` = `â¶`
- `…` (`E2 80 A6`), `é` (`C3 A9`), etc.

Native CC strings are unaffected precisely because they're already `\uXXXX`-escaped — so the fix is to make our injections match that convention.

(Confirmed by extracting the claude module: it contains 1000+ `\uXXXX` escape sequences and only a handful of raw multibyte bytes; the raw bytes we inject are the only ones that mojibake.)

## Fix

Add `escapeNonAscii()` (`src/utils.ts`), which rewrites every ``–`￿` code unit to `\uXXXX` (surrogate-safe), and apply it at every site that injects non-ASCII into the patched source:

- **thinkerSymbolChars** — spinner phase glyphs
- **thinkingVerbs** — present/past-tense verb arrays (e.g. accented `Flambéing`)
- **thinkerFormat** — the spinner-verb format string (e.g. `{}… `); escaped **last** so it only introduces single-backslash `\uXXXX` after the existing backslash-doubling pass
- **patchesAppliedIndication** — the `┃`/`✓` startup-notice glyphs

It is safe over `JSON.stringify(...)` output and over freshly-built string/template-literal contents because a raw non-ASCII char is never preceded there by a lone backslash.

## Testing

- New `escapeNonAscii` unit tests (ASCII passthrough, BMP glyph escaping, astral surrogate pairs, round-trip + pure-ASCII output).
- Updated one `thinkerFormat` assertion that had encoded the old (buggy) raw output.
- Full suite green (`pnpm test`, `tsc --noEmit`, `eslint`).
- Verified end-to-end against Claude Code 2.1.185: rebuilt the patched binary and captured a startup frame in a pty — **0** `â` (`C3 A2`) mojibake bytes on the wire (was 39), and the injected notice bullets now emit correct UTF-8 `┃` (`E2 94 83`).
