### PR TITLE
feat: [experimental] complexity effort router

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ import chalk from 'chalk';
 
 import {
   RemoteConfig,
+  RouterLevel,
   Settings,
   Theme,
   ThinkingVerbsConfig,
@@ -238,6 +239,24 @@ const normalizeConfig = (config: TweakccConfig): void => {
     config.settings.themes = config.settings.themes.map(
       theme => deepMergeWithDefaults(theme, DEFAULT_THEME) as Theme
     );
+  }
+
+  // Merge each complexityRouter level against the default level at its index.
+  // deepMergeWithDefaults replaces arrays wholesale, so a hand-edited or remote
+  // (--config-url) level missing `effort` would otherwise leave a null effort
+  // that silently no-ops the router; backfill it from the matching default.
+  if (config.settings.complexityRouter?.levels) {
+    const defaultLevels = DEFAULT_SETTINGS.complexityRouter!.levels;
+    config.settings.complexityRouter.levels =
+      config.settings.complexityRouter.levels.map((level, i) => {
+        const def = defaultLevels[Math.min(i, defaultLevels.length - 1)];
+        const merged = deepMergeWithDefaults(level, def) as RouterLevel;
+        // deepMerge only fills ABSENT keys, so an explicit null/empty effort
+        // (reachable via --config-url) would survive and silently no-op the
+        // router; coerce it to the default.
+        if (!merged.effort) merged.effort = def.effort;
+        return merged;
+      });
   }
 
   // In 3.2.6 hideCtrlGToEditPrompt was renamed to hideCtrlGToEdit.

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ import chalk from 'chalk';
 
 import {
   RemoteConfig,
+  RouterEffort,
   RouterLevel,
   Settings,
   Theme,
@@ -241,22 +242,38 @@ const normalizeConfig = (config: TweakccConfig): void => {
     );
   }
 
-  // Merge each complexityRouter level against the default level at its index.
-  // deepMergeWithDefaults replaces arrays wholesale, so a hand-edited or remote
-  // (--config-url) level missing `effort` would otherwise leave a null effort
-  // that silently no-ops the router; backfill it from the matching default.
-  if (config.settings.complexityRouter?.levels) {
-    const defaultLevels = DEFAULT_SETTINGS.complexityRouter!.levels;
-    config.settings.complexityRouter.levels =
-      config.settings.complexityRouter.levels.map((level, i) => {
-        const def = defaultLevels[Math.min(i, defaultLevels.length - 1)];
-        const merged = deepMergeWithDefaults(level, def) as RouterLevel;
-        // deepMerge only fills ABSENT keys, so an explicit null/empty effort
-        // (reachable via --config-url) would survive and silently no-op the
-        // router; coerce it to the default.
-        if (!merged.effort) merged.effort = def.effort;
-        return merged;
-      });
+  // Harden complexityRouter.levels against hand-edited / remote (--config-url)
+  // configs. An empty array, a non-array value, or absent levels all fall back
+  // to the defaults (matching the TUI's `length > 0` guard) so an ENABLED router
+  // never silently no-ops or crashes on `.map`. Each level is merged against the
+  // default at its index, its effort coerced to a valid RouterEffort (deepMerge
+  // only fills ABSENT keys, so a garbage or null effort would otherwise survive
+  // and either no-op the router or ship an invalid value to the wire), and a
+  // unique id synthesized for overflow levels so React list keys can't collide.
+  {
+    const cr = config.settings.complexityRouter;
+    const defaultLevels = DEFAULT_SETTINGS.complexityRouter.levels;
+    const validEfforts: RouterEffort[] = [
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max',
+    ];
+    cr.levels =
+      Array.isArray(cr.levels) && cr.levels.length > 0
+        ? cr.levels.map((level, i) => {
+            const def = defaultLevels[Math.min(i, defaultLevels.length - 1)];
+            const merged = deepMergeWithDefaults(level, def) as RouterLevel;
+            if (!(validEfforts as string[]).includes(merged.effort)) {
+              merged.effort = def.effort;
+            }
+            if (i >= defaultLevels.length) {
+              merged.id = `level-${i}`;
+            }
+            return merged;
+          })
+        : defaultLevels.map(l => ({ ...l }));
   }
 
   // In 3.2.6 hideCtrlGToEditPrompt was renamed to hideCtrlGToEdit.

--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -737,6 +737,37 @@ export const DEFAULT_SETTINGS: Settings = {
     explore: null,
     generalPurpose: null,
   },
+  complexityRouter: {
+    enabled: false,
+    mode: 'heuristic',
+    pinPerTask: true,
+    levels: [
+      {
+        id: 'routine',
+        label: 'Routine',
+        help: 'Mechanical edits, renames, search/grep summarization, boilerplate',
+        effort: 'low',
+      },
+      {
+        id: 'standard',
+        label: 'Standard',
+        help: 'The workhorse - standard coding/tool work; most traffic',
+        effort: 'medium',
+      },
+      {
+        id: 'hard',
+        label: 'Hard',
+        help: 'Architecture, cross-file refactor, deep debug/review',
+        effort: 'high',
+      },
+      {
+        id: 'frontier',
+        label: 'Frontier',
+        help: "Only the hardest; reached on explicit max-effort phrases (e.g. 'ultrathink') or when many hard signals stack up",
+        effort: 'max',
+      },
+    ],
+  },
   inputPatternHighlighters: [],
   inputPatternHighlightersTestText: 'Type test text here to see highlighting',
   claudeMdAltNames: [

--- a/src/patches/complexityRouter.test.ts
+++ b/src/patches/complexityRouter.test.ts
@@ -377,6 +377,23 @@ describe('writeComplexityRouter', () => {
       await classify('rename the variable', 'prompt'); // trivial -> low
       expect(XQ('m', 'xhigh')).toBe('low'); // persisted xhigh overridden, routed all the way down
     });
+
+    it('captures the launch baseline on the first resolve while the router is still inactive (boot ordering)', async () => {
+      // Production order: eZ resolves (a pre-submit poll) and captures the
+      // baseline BEFORE any classify sets an effort - the inverse of the
+      // seed-effort-first shape the other precedence tests use.
+      const p = patched();
+      const XQ = extractWrappedResolver(p);
+      const classify = extractClassify(p); // shares globalThis.__tweakccRouter
+      // 1) router inactive (no effort yet): the first resolve captures baseline
+      expect(XQ('m', 'xhigh')).toBe('YIELDED'); // no router effort -> CC's own resolution
+      expect(routerState().baseline).toBe('xhigh');
+      // 2) a routine task classifies -> low
+      await classify('rename the variable', 'prompt');
+      expect(routerState().effort).toBe('low');
+      // 3) resolve again: fallback still == baseline -> the router now drives
+      expect(XQ('m', 'xhigh')).toBe('low');
+    });
   });
 
   describe('llm classifier (real injected logic, H1 regression)', () => {

--- a/src/patches/complexityRouter.test.ts
+++ b/src/patches/complexityRouter.test.ts
@@ -1,0 +1,414 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { writeComplexityRouter } from './complexityRouter';
+import { ComplexityRouterConfig } from '../types';
+
+// Faithful CC 2.1.186 (darwin) minified shapes the patch anchors on.
+const XQ_SHAPE =
+  'function XQ(e,t){if(!FR(e))return;let n=fUe(e),r=Tbn(e),o=mUe();' +
+  'if(o===null)return n?r:void 0;let s=o??(n?r:void 0)??t??r;' +
+  'if(s==="max"&&!dUe(e))return"high";if(s==="xhigh"&&!GRe(e))return"high";return s}';
+
+// hMm submit handler (trimmed): the throw-guard is the stable hook anchor.
+const HMM_SHAPE =
+  'async function hMm(e,t,n,r){let E=null,k=e;if(typeof e==="string")E=e;' +
+  'if(E===null&&t!=="prompt")throw Error(`Mode: ${t} requires a string input.`);' +
+  'return cZn(aVl(E,k),[])}';
+
+// gB pins model:HR() - the cheap one-shot structured classifier we want.
+const GB_SHAPE =
+  'async function gB({systemPrompt:e=vc([]),userPrompt:t,outputFormat:n,signal:r,options:o}){' +
+  'return(await qWn([Ln({content:e.map((i)=>({type:"text",text:i}))}),Ln({content:t})],async()=>{' +
+  'let i=[Ln({content:t})];return[await DWe({messages:i,systemPrompt:e,thinkingConfig:{type:"disabled"},' +
+  'tools:[],signal:r,options:{...o,stickyBetas:o.stickyBetas??o0(WH()),agentContext:o.agentContext,' +
+  'model:HR(),enablePromptCaching:o.enablePromptCaching??!1,outputFormat:n,' +
+  'async getToolPermissionContext(){return WM()}}})]}))[0]}';
+
+// Vpt is gB's twin - same signature, but NO pinned model (uses the caller's).
+const VPT_SHAPE =
+  'async function Vpt({systemPrompt:e=vc([]),userPrompt:t,outputFormat:n,signal:r,options:o}){' +
+  'return(await qWn([Ln({content:e.map((i)=>({type:"text",text:i}))}),Ln({content:t})],async()=>{' +
+  'let i=[Ln({content:t})];return[await DWe({messages:i,systemPrompt:e,thinkingConfig:{type:"disabled"},' +
+  'tools:[],signal:r,options:{...o,stickyBetas:o.stickyBetas??o0(WH()),agentContext:o.agentContext,' +
+  'enablePromptCaching:o.enablePromptCaching??!1,outputFormat:n,' +
+  'async getToolPermissionContext(){return WM()}}})]}))[0]}';
+
+// km agent-context builder (required by the llm classifier).
+const KM_SHAPE = 'function km(){return{agentType:"main",agentId:xt()}}';
+
+const FILE = `var head=1;${GB_SHAPE}${VPT_SHAPE}${KM_SHAPE}${XQ_SHAPE}${HMM_SHAPE}var tail=2;`;
+
+const cfg = (
+  over: Partial<ComplexityRouterConfig> = {}
+): ComplexityRouterConfig => ({
+  enabled: true,
+  mode: 'heuristic',
+  pinPerTask: true,
+  levels: [
+    { id: 'routine', label: 'Routine', help: '', effort: 'low' },
+    { id: 'standard', label: 'Standard', help: '', effort: 'medium' },
+    { id: 'hard', label: 'Hard', help: '', effort: 'high' },
+    { id: 'frontier', label: 'Frontier', help: '', effort: 'max' },
+  ],
+  ...over,
+});
+
+// Run a generated async function body's syntax through the parser without
+// executing it (free identifiers like gB/FR resolve at call time, not parse).
+const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
+const assertParses = (src: string) => {
+  expect(() => new AsyncFunction(src)).not.toThrow();
+};
+
+// Pull the generated heuristic scorer out and make it callable so we test the
+// REAL injected logic (not a TS re-implementation).
+const extractScorer = (
+  patched: string
+): ((t: string, max: number) => number) => {
+  const m = patched.match(/function __tweakccRouterScore[\s\S]*?return __l\}/);
+  if (!m) throw new Error('scorer not found in patched output');
+  return new Function(m[0] + ';return __tweakccRouterScore;')() as (
+    t: string,
+    max: number
+  ) => number;
+};
+
+// Extract the whole heuristic runtime (state + scorer + classify) and return a
+// callable classify(text, mode) that reads/writes globalThis.__tweakccRouter.
+const extractClassify = (
+  patched: string
+): ((text: string, mode: string) => Promise<void>) => {
+  const m = patched.match(
+    /function __tweakccRouterState[\s\S]*?(?=function XQ\()/
+  );
+  if (!m) throw new Error('runtime not found in patched output');
+  return new Function(m[0] + ';return __tweakccRouterClassify;')() as (
+    text: string,
+    mode: string
+  ) => Promise<void>;
+};
+
+const routerState = () =>
+  (
+    globalThis as unknown as Record<
+      string,
+      { level?: number; effort?: string; baseline?: string | null }
+    >
+  ).__tweakccRouter;
+
+// Extract the runtime + the WRAPPED resolver and make XQ callable with stubbed
+// CC helpers, so we exercise the REAL precedence logic (env / baseline / guards).
+const extractWrappedResolver = (
+  patched: string,
+  overrides: Record<string, (...a: unknown[]) => unknown> = {}
+): ((e: string, t: unknown) => unknown) => {
+  const m = patched.match(
+    /function __tweakccRouterState[\s\S]*?function XQ\([\s\S]*?return s\}/
+  );
+  if (!m) throw new Error('wrapped resolver not found in patched output');
+  const stubs: Record<string, (...a: unknown[]) => unknown> = {
+    FR: () => true, // supports effort
+    fUe: () => true, // launch-pin flag
+    Tbn: () => 'YIELDED', // per-model default = sentinel for "fell through"
+    mUe: () => null, // CLAUDE_CODE_EFFORT_LEVEL unset
+    dUe: () => true, // supports max
+    GRe: () => true, // supports xhigh
+    ...overrides,
+  };
+  const names = ['FR', 'fUe', 'Tbn', 'mUe', 'dUe', 'GRe'];
+  return new Function(...names, m[0] + ';return XQ;')(
+    ...names.map(n => stubs[n])
+  ) as (e: string, t: unknown) => unknown;
+};
+
+const setRouterState = (s: {
+  level?: number;
+  effort?: string;
+  baseline?: string | null;
+}) => {
+  (globalThis as unknown as Record<string, unknown>).__tweakccRouter = s;
+};
+
+describe('writeComplexityRouter', () => {
+  it('wraps the effort resolver and hooks the submit handler (heuristic)', () => {
+    const out = writeComplexityRouter(FILE, cfg());
+    expect(out).not.toBeNull();
+    const r = out as string;
+    expect(r).toContain('function __tweakccRouterClassify');
+    expect(r).toContain('function __tweakccRouterScore');
+    expect(r).toContain('var __st=__tweakccRouterState();');
+    expect(r).toContain('let __twkRE=__st.effort;');
+    expect(r).toContain('if(__twkRE&&o==null&&(t==null||t===__st.baseline))');
+    expect(r).toContain('!dUe(e)');
+    expect(r).toContain('!GRe(e)');
+    expect(r).toContain('await __tweakccRouterClassify(E,t);');
+    expect(r).toContain('var head=1;');
+    expect(r).toContain('var tail=2;');
+    expect(r).not.toContain('__tweakccRouterClassifyLlm');
+  });
+
+  it('produces syntactically valid injected JS', () => {
+    assertParses(writeComplexityRouter(FILE, cfg()) as string);
+    assertParses(writeComplexityRouter(FILE, cfg({ mode: 'llm' })) as string);
+  });
+
+  it('is idempotent', () => {
+    const once = writeComplexityRouter(FILE, cfg()) as string;
+    expect(writeComplexityRouter(once, cfg())).toBe(once);
+  });
+
+  it('introduces no non-ASCII codepoints (mojibake guard)', () => {
+    const out = writeComplexityRouter(FILE, cfg({ mode: 'llm' })) as string;
+    const maxCp = out
+      .split('')
+      .reduce((m, ch) => Math.max(m, ch.charCodeAt(0)), 0);
+    expect(maxCp).toBeLessThanOrEqual(0x7f);
+  });
+
+  it('emits the llm classifier targeting gB with the full options shape', () => {
+    const out = writeComplexityRouter(FILE, cfg({ mode: 'llm' })) as string;
+    expect(out).toContain('__tweakccRouterClassifyLlm');
+    expect(out).toContain('await gB({systemPrompt:[__sys]');
+    // H1: agentContext is REQUIRED or gB throws on every call.
+    expect(out).toContain('agentContext:km()');
+    expect(out).toContain('querySource:"route_complexity"');
+    expect(out).not.toContain('await Vpt(');
+  });
+
+  it('falls back to heuristic when llm mode finds no gB/km helpers', () => {
+    const noGb = `var head=1;${XQ_SHAPE}${HMM_SHAPE}var tail=2;`;
+    const out = writeComplexityRouter(noGb, cfg({ mode: 'llm' })) as string;
+    expect(out).not.toBeNull();
+    expect(out).toContain('function __tweakccRouterClassify');
+    expect(out).not.toContain('__tweakccRouterClassifyLlm');
+  });
+
+  it('no-ops gracefully when the effort resolver is absent', () => {
+    const file = 'var x=1;function y(){return 2}';
+    expect(writeComplexityRouter(file, cfg())).toBe(file);
+  });
+
+  it('fails (null) when effort machinery is present but the shape drifted', () => {
+    const drifted =
+      'var x="CLAUDE_CODE_EFFORT_LEVEL";function z(){return"high"}';
+    expect(writeComplexityRouter(drifted, cfg())).toBeNull();
+  });
+
+  it('reverts the whole patch (no half-patch) when the submit handler is absent', () => {
+    // XQ present but the submit-throw anchor absent: must NOT ship the wrap +
+    // runtime with no classify call to populate the global (all-or-nothing).
+    const noSubmit = `var head=1;${XQ_SHAPE}var tail=2;`;
+    expect(noSubmit.includes('requires a string input.')).toBe(false);
+    expect(writeComplexityRouter(noSubmit, cfg())).toBe(noSubmit);
+  });
+
+  describe('heuristic scorer (real injected logic)', () => {
+    const score = extractScorer(writeComplexityRouter(FILE, cfg()) as string);
+
+    it('defaults plain requests to Standard (level 1)', () => {
+      expect(score('rename this variable to userCount', 3)).toBe(1);
+      expect(score('add a comment to this function', 3)).toBe(1);
+    });
+
+    it('escalates one strong signal to Hard (level 2)', () => {
+      expect(score('fix the race condition in the worker pool', 3)).toBe(2);
+      expect(score('refactor the auth module across files', 3)).toBe(2);
+      expect(
+        score('there is a security vulnerability in the login flow', 3)
+      ).toBe(2);
+    });
+
+    it('jumps to the top tier on explicit max-escalation phrases', () => {
+      expect(score('ultrathink about this and solve it', 3)).toBe(3);
+    });
+
+    it('reaches the top tier on heavy signal accumulation', () => {
+      const heavy =
+        'we have a race condition and a security vulnerability; refactor ' +
+        'across modules and fix the deadlock. why is it flaky? optimize the ' +
+        'algorithm too. this is production critical.';
+      expect(score(heavy, 3)).toBe(3);
+    });
+
+    it('never routes below the base level on short/empty input', () => {
+      expect(score('', 3)).toBe(1);
+      expect(score('hi', 3)).toBe(1);
+    });
+
+    it('clamps to the configured max level', () => {
+      expect(score('ultrathink hard about everything', 2)).toBe(2);
+    });
+
+    it('stays fast (linear) on long single-line pastes (ReDoS guard)', () => {
+      // Pre-fix these froze the TUI for 1-3.5s; the input cap + bounded
+      // quantifiers keep it well under a frame.
+      for (const big of [
+        'a'.repeat(60000) + 'exception:', // [\w.$]+(error|exception): prefix
+        'a'.repeat(60000), // plain run
+        'https://example.com/' + 'a'.repeat(60000), // long single token
+        'a.'.repeat(40000), // path-count [\w./-]+\.[a-z]{1,5}
+        'at x(' + '1'.repeat(60000), // stack-trace \d+:\d+ near-miss
+        '('.repeat(60000), // many open parens
+      ]) {
+        const t0 = performance.now();
+        const lvl = score(big, 3);
+        expect(performance.now() - t0).toBeLessThan(100);
+        expect(lvl).toBeGreaterThanOrEqual(1);
+      }
+    });
+  });
+
+  describe('classify entry point (real injected logic)', () => {
+    beforeEach(() => {
+      delete (globalThis as unknown as Record<string, unknown>).__tweakccRouter;
+    });
+
+    it('writes the level effort and escalates monotonically when pinned', async () => {
+      const classify = extractClassify(
+        writeComplexityRouter(FILE, cfg()) as string
+      );
+      await classify('rename the variable', 'prompt'); // level 1 -> medium
+      expect(routerState().effort).toBe('medium');
+      await classify('fix the race condition', 'prompt'); // level 2 -> high
+      expect(routerState().effort).toBe('high');
+      await classify('just rename this thing', 'prompt'); // level 1, pinned -> stays high
+      expect(routerState().effort).toBe('high');
+    });
+
+    it('re-rates up AND down when pinPerTask is off', async () => {
+      const classify = extractClassify(
+        writeComplexityRouter(FILE, cfg({ pinPerTask: false })) as string
+      );
+      await classify('fix the race condition', 'prompt'); // high
+      expect(routerState().effort).toBe('high');
+      await classify('rename this thing', 'prompt'); // level 1 -> medium (down allowed)
+      expect(routerState().effort).toBe('medium');
+    });
+
+    it('resets the pin on /clear (incl. trailing whitespace)', async () => {
+      const classify = extractClassify(
+        writeComplexityRouter(FILE, cfg()) as string
+      );
+      await classify('fix the race condition', 'prompt');
+      await classify('/clear\n', 'prompt');
+      expect(routerState().level).toBeUndefined();
+    });
+
+    it('ignores other slash commands and non-prompt modes', async () => {
+      const classify = extractClassify(
+        writeComplexityRouter(FILE, cfg()) as string
+      );
+      await classify('/theme', 'prompt');
+      await classify('ls -la', 'bash');
+      expect(routerState().effort).toBeUndefined();
+    });
+
+    it('drops the captured baseline on /clear so the router resumes', async () => {
+      const classify = extractClassify(
+        writeComplexityRouter(FILE, cfg()) as string
+      );
+      await classify('fix the race condition', 'prompt');
+      routerState().baseline = 'xhigh'; // simulate the wrap having captured it
+      await classify('/clear\n', 'prompt');
+      expect(routerState().level).toBeUndefined();
+      expect(routerState().effort).toBeUndefined();
+      expect(routerState().baseline).toBeUndefined(); // re-captured fresh next resolve
+    });
+  });
+
+  describe('effort-resolver wrap precedence (real injected logic)', () => {
+    beforeEach(() => {
+      delete (globalThis as unknown as Record<string, unknown>).__tweakccRouter;
+    });
+
+    const patched = () => writeComplexityRouter(FILE, cfg()) as string;
+
+    it('OVERRIDES a persisted effort baseline (the inert-router bug)', () => {
+      // User has settings.effortLevel=xhigh -> arrives as the app-state fallback.
+      // The router must win over it (deferring would make the router silently inert).
+      setRouterState({ level: 1, effort: 'medium', baseline: undefined });
+      const XQ = extractWrappedResolver(patched());
+      expect(XQ('m', 'xhigh')).toBe('medium'); // baseline<-xhigh; t===baseline -> router drives
+      expect(XQ('m', 'xhigh')).toBe('medium'); // stays driven across turns
+    });
+
+    it('YIELDS to an in-session /effort (fallback diverges from the launch baseline)', () => {
+      setRouterState({ level: 1, effort: 'medium', baseline: undefined });
+      const XQ = extractWrappedResolver(patched());
+      expect(XQ('m', 'xhigh')).toBe('medium'); // launch baseline captured = xhigh
+      expect(XQ('m', 'low')).toBe('YIELDED'); // user /effort'd to low -> router steps aside
+    });
+
+    it('YIELDS to the CLAUDE_CODE_EFFORT_LEVEL env pin', () => {
+      setRouterState({ level: 1, effort: 'medium', baseline: undefined });
+      // env set -> o!=null -> wrap never fires; CC's own resolution returns it.
+      const XQ = extractWrappedResolver(patched(), { mUe: () => 'high' });
+      expect(XQ('m', 'xhigh')).toBe('high');
+    });
+
+    it('drives when nothing is pinned (baseline null) and re-applies support guards', () => {
+      setRouterState({ level: 1, effort: 'medium', baseline: undefined });
+      const XQ = extractWrappedResolver(patched());
+      expect(XQ('m', undefined)).toBe('medium'); // t unset -> baseline null -> router drives
+      // unsupported routed level downgrades to "high"
+      setRouterState({ level: 3, effort: 'max', baseline: undefined });
+      const XQ2 = extractWrappedResolver(patched(), { dUe: () => false });
+      expect(XQ2('m', undefined)).toBe('high');
+    });
+
+    it('end-to-end: real classify sets the effort, the real wrap overrides a persisted baseline', async () => {
+      // Faithful full path: classify (writes the global) -> wrapped resolver
+      // (reads it) with a non-null fallback standing in for settings.effortLevel.
+      // This is the exact runtime flow the original unit tests did NOT model.
+      const p = patched();
+      const classify = extractClassify(p);
+      const XQ = extractWrappedResolver(p); // shares globalThis.__tweakccRouter
+      await classify('rename the variable', 'prompt'); // level 1 -> medium
+      expect(XQ('m', 'xhigh')).toBe('medium'); // persisted xhigh overridden by the router
+    });
+  });
+
+  describe('llm classifier (real injected logic, H1 regression)', () => {
+    // Extract the emitted llm classifier + result parser and run it against a
+    // stub gB/km so we PROVE it passes agentContext and parses the level.
+    const buildLlm = () => {
+      const patched = writeComplexityRouter(
+        FILE,
+        cfg({ mode: 'llm' })
+      ) as string;
+      const m = patched.match(
+        /async function __tweakccRouterClassifyLlm[\s\S]*?(?=async function __tweakccRouterClassify\()/
+      );
+      if (!m) throw new Error('llm classifier not found');
+      let captured: { options?: Record<string, unknown> } = {};
+      const stubGB = async (opts: { options?: Record<string, unknown> }) => {
+        captured = opts;
+        return {
+          message: { content: [{ type: 'text', text: '{"level":2}' }] },
+        };
+      };
+      const km = () => ({ agentType: 'main', agentId: 'x' });
+      const fn = new Function(
+        'gB',
+        'km',
+        'AbortController',
+        'setTimeout',
+        'clearTimeout',
+        m[0] + ';return __tweakccRouterClassifyLlm;'
+      )(stubGB, km, AbortController, setTimeout, clearTimeout) as (
+        t: string,
+        max: number
+      ) => Promise<number | null>;
+      return { fn, getCaptured: () => captured };
+    };
+
+    it('passes a valid agentContext (would TypeError without it) and parses the level', async () => {
+      const { fn, getCaptured } = buildLlm();
+      const level = await fn('refactor the whole auth subsystem', 3);
+      expect(level).toBe(2);
+      const opts = getCaptured().options as Record<string, unknown>;
+      expect(opts.agentContext).toEqual({ agentType: 'main', agentId: 'x' });
+      expect(opts.querySource).toBe('route_complexity');
+      expect(opts.agents).toEqual([]);
+    });
+  });
+});

--- a/src/patches/complexityRouter.test.ts
+++ b/src/patches/complexityRouter.test.ts
@@ -204,9 +204,21 @@ describe('writeComplexityRouter', () => {
   describe('heuristic scorer (real injected logic)', () => {
     const score = extractScorer(writeComplexityRouter(FILE, cfg()) as string);
 
-    it('defaults plain requests to Standard (level 1)', () => {
-      expect(score('rename this variable to userCount', 3)).toBe(1);
-      expect(score('add a comment to this function', 3)).toBe(1);
+    it('routes confidently-trivial work down to Routine (level 0)', () => {
+      expect(score('rename this variable to userCount', 3)).toBe(0);
+      expect(score('fix the typo in the readme', 3)).toBe(0);
+      expect(score('add a comment to this function', 3)).toBe(0);
+      expect(score('bump the version to 2.0.1', 3)).toBe(0);
+    });
+
+    it('keeps genuinely-ambiguous work at the Standard default (level 1)', () => {
+      expect(score('update the user profile page', 3)).toBe(1);
+      expect(score('change the button color to blue', 3)).toBe(1);
+    });
+
+    it('does not route to low once any hard signal is present', () => {
+      // a trivial verb + a hard signal must NOT drop to low
+      expect(score('rename things while fixing the race condition', 3)).toBe(2);
     });
 
     it('escalates one strong signal to Hard (level 2)', () => {
@@ -229,7 +241,7 @@ describe('writeComplexityRouter', () => {
       expect(score(heavy, 3)).toBe(3);
     });
 
-    it('never routes below the base level on short/empty input', () => {
+    it('keeps empty/contentless input at the Standard default (no trivial verb)', () => {
       expect(score('', 3)).toBe(1);
       expect(score('hi', 3)).toBe(1);
     });
@@ -266,11 +278,11 @@ describe('writeComplexityRouter', () => {
       const classify = extractClassify(
         writeComplexityRouter(FILE, cfg()) as string
       );
-      await classify('rename the variable', 'prompt'); // level 1 -> medium
-      expect(routerState().effort).toBe('medium');
+      await classify('rename the variable', 'prompt'); // trivial -> low
+      expect(routerState().effort).toBe('low');
       await classify('fix the race condition', 'prompt'); // level 2 -> high
       expect(routerState().effort).toBe('high');
-      await classify('just rename this thing', 'prompt'); // level 1, pinned -> stays high
+      await classify('just rename this thing', 'prompt'); // trivial, pinned -> stays high
       expect(routerState().effort).toBe('high');
     });
 
@@ -280,8 +292,8 @@ describe('writeComplexityRouter', () => {
       );
       await classify('fix the race condition', 'prompt'); // high
       expect(routerState().effort).toBe('high');
-      await classify('rename this thing', 'prompt'); // level 1 -> medium (down allowed)
-      expect(routerState().effort).toBe('medium');
+      await classify('rename this thing', 'prompt'); // trivial -> low (down allowed)
+      expect(routerState().effort).toBe('low');
     });
 
     it('resets the pin on /clear (incl. trailing whitespace)', async () => {
@@ -362,8 +374,8 @@ describe('writeComplexityRouter', () => {
       const p = patched();
       const classify = extractClassify(p);
       const XQ = extractWrappedResolver(p); // shares globalThis.__tweakccRouter
-      await classify('rename the variable', 'prompt'); // level 1 -> medium
-      expect(XQ('m', 'xhigh')).toBe('medium'); // persisted xhigh overridden by the router
+      await classify('rename the variable', 'prompt'); // trivial -> low
+      expect(XQ('m', 'xhigh')).toBe('low'); // persisted xhigh overridden, routed all the way down
     });
   });
 

--- a/src/patches/complexityRouter.ts
+++ b/src/patches/complexityRouter.ts
@@ -56,6 +56,19 @@
 // subagents (on an effort-capable model) inherit the task's effort. Side-calls
 // on Haiku-class models are unaffected (Haiku does not take effort, so XQ
 // returns at its `!FR(e)` guard, before the wrap).
+// CC's picker-internal comparators also resolve through the wrapped eZ: the
+// /effort and /model pickers call it to decide "did effort change?" (gDt) and to
+// pre-select the ultracode row (tZ). After >=1 completed turn these reflect the
+// ROUTED value rather than the raw effortValue - cosmetic only (the picker change
+// still applies and the /effort yield still works).
+//
+// -- Interaction: ultracode --
+// CC's "ultracode" mode is gated on the RESOLVED effort being exactly "xhigh"
+// (tZ: `...&&eZ(e,t)==="xhigh"`). The default tiers map to low/medium/high/max
+// (never xhigh), so while the router drives, ultracode-gated behavior (the
+// workflow usage-consent prompt, the /fast hint, the ultracode status flag) goes
+// inactive for a user whose effort baseline was xhigh. To keep ultracode
+// reachable, map a tier's effort to "xhigh" (a valid RouterEffort).
 //
 // -- Behavior --
 // pinPerTask (default true): keep the effort stable across a session. Heuristic
@@ -160,7 +173,10 @@ const buildRuntime = (
       ? `var __max=__ef.length-1,__lv;` +
         `if(__pin&&__st.level!==void 0){__lv=__st.level}` +
         `else{try{__lv=await __tweakccRouterClassifyLlm(__text,__max)}catch(__e){__lv=null}` +
-        `if(__lv==null||__lv<0||__lv>__max)__lv=__tweakccRouterScore(__text,__max)}`
+        // !Number.isInteger catches a non-conforming gB result (float/NaN): NaN
+        // passes the </> comparisons, and __ef[float] is undefined -> the router
+        // would silently yield (and pin the bad level). Fail OPEN to the heuristic.
+        `if(__lv==null||!Number.isInteger(__lv)||__lv<0||__lv>__max)__lv=__tweakccRouterScore(__text,__max)}`
       : `var __max=__ef.length-1,__lv=__tweakccRouterScore(__text,__max);` +
         `if(__pin&&__st.level!==void 0&&__lv<__st.level)__lv=__st.level;`;
 
@@ -191,12 +207,16 @@ const buildRuntime = (
     `if((__t.match(/\`\`\`/g)||[]).length>=4)__n+=1;` +
     // Decide the level: confident-trivial work (an explicit mechanical verb with
     // ZERO hard signals) routes DOWN to low (0); ambiguous work stays at the
-    // medium default (1); accumulated signals escalate up; explicit max-effort
-    // phrases jump straight to the top tier.
+    // medium default (1); a hard signal escalates to the "hard" tier (index 2);
+    // heavy accumulation OR an explicit max-effort phrase jumps to the TOP tier
+    // (__max, so it tracks the configured level count). The trivial->0 and
+    // hard->2 mappings target the default 4-tier layout (routine/standard/hard/
+    // frontier); a custom level count clamps sensibly, and llm mode gives finer
+    // per-tier control.
     `var __triv=__n===0&&/\\b(rename|fix (?:the |a )?typos?|typos?|reformat|run (?:the )?prettier|prettier|gofmt|sort (?:the )?imports|bump (?:the )?version|add (?:a )?(?:comment|docstring|jsdoc)|remove (?:the |a )?(?:comment|console\\.log|unused import|debug (?:log|statement)))\\b/.test(__s);` +
     `var __l;` +
     `if(/\\b(ultrathink|think as hard as|maximum effort|hardest possible|frontier model)/.test(__s))__l=__max;` +
-    `else if(__n>=5)__l=3;` +
+    `else if(__n>=5)__l=__max;` +
     `else if(__n>=2)__l=2;` +
     `else if(__triv)__l=0;` +
     `else __l=1;` +

--- a/src/patches/complexityRouter.ts
+++ b/src/patches/complexityRouter.ts
@@ -78,11 +78,13 @@
 // reachable solely when the model's launch-pin gate is open) could it capture a
 // picker candidate. /clear re-captures a fresh baseline, recovering from both.
 //
-// -- Observability (no extra patch needed) --
-// CC's statusline-command input JSON builds `effort.level` via `sO -> eZ` (the
-// resolver we wrap: `sO(e,t)=Gfe(eZ(e,t)??"high")`), so the routed effort already
-// rides into a custom statusline's stdin - a script can read `.effort.level` to
-// render a badge. `TWEAKCC_ROUTER_DEBUG=1` also logs each decision to stderr.
+// -- Observability (automatic, no extra patch) --
+// Because the wrap rides on the effort resolver eZ, CC surfaces the routed effort
+// for free. Its working indicator renders ` with ${fet(e,t)} effort` where
+// `fet -> eZ`, so the spinner reads e.g. "thinking with max effort" for EVERY
+// user, no setup. (The statusline-command input JSON also carries it as
+// effort.level via `sO -> eZ`, for a custom always-on badge.) And
+// TWEAKCC_ROUTER_DEBUG=1 logs each decision to stderr.
 
 import { debug } from '../utils';
 import { showDiff } from './index';

--- a/src/patches/complexityRouter.ts
+++ b/src/patches/complexityRouter.ts
@@ -1,0 +1,371 @@
+// Please see the note about writing patches in ./index
+//
+// [EXPERIMENTAL] Complexity effort router.
+//
+// Classifies how hard each task is into an ordinal level and sets the session's
+// reasoning-effort (thinking) level accordingly - routine work runs at low
+// effort (fast, cheap), the hardest work at max. It rides on whatever model the
+// user is already on (Opus 4.8 by default): a pure thinking-depth dial, no model
+// switch. Changing the effort level is NOT a prompt-cache invalidator - per the
+// Anthropic caching hierarchy only model and tool-definition changes rebuild the
+// cache, and effort-level changes are not listed - so routing the effort never
+// churns the prompt cache or adds cost. Off by default.
+//
+// -- Mechanism (illustrated with CC 2.1.186 darwin names; verified on 2.1.186
+// and 2.1.187). Minified names churn per version/platform, so every anchor
+// CAPTURES them from the binary at apply time - never hardcode a name. --
+//
+// CC resolves a turn's effort through a single resolver:
+//
+//   function XQ(e,t){if(!FR(e))return;let n=fUe(e),r=Tbn(e),o=mUe();
+//     if(o===null)return n?r:void 0;let s=o??(n?r:void 0)??t??r;
+//     if(s==="max"&&!dUe(e))return"high";if(s==="xhigh"&&!GRe(e))return"high";return s}
+//
+// where e=model, FR=supports-effort, mUe=CLAUDE_CODE_EFFORT_LEVEL env (env-only:
+// it reads process.env, NOT settings), dUe=supports-max, GRe=supports-xhigh, and
+// t=the app-state effort FALLBACK - which carries BOTH the persisted
+// settings.effortLevel baseline (loaded at launch) AND an in-session /effort
+// (they share one app-state slot). The outgoing request's effort lands in
+// output_config.effort as nO(model,effortValue) -> XQ, so XQ is the wire
+// chokepoint.
+//
+// We wrap XQ to return the router's effort, OVERRIDING the persisted baseline (so
+// the router actually routes for the common case of a user who set a global
+// effortLevel - deferring to it would make the router silently inert) while still
+// yielding to a deliberate pin:
+//   - the CLAUDE_CODE_EFFORT_LEVEL env var (`o` != null), and
+//   - an in-session /effort, detected as the fallback `t` diverging from the
+//     launch baseline we capture on first resolve. Equal-to-baseline (or unset)
+//     means the user has not touched effort this session, so the router drives;
+//     once they /effort to a different value the router yields for the rest of
+//     the session (until set back, or /clear).
+// The support guards (dUe/GRe) are re-applied so an unsupported level still
+// downgrades to "high".
+//
+// The classify hook splices into CC's submit handler (anchor: the stable
+// "requires a string input." throw), where the finalized user text `E` and the
+// submit mode `t` are in scope. On a plain prompt it runs the synchronous
+// heuristic scorer (or, in `llm` mode, an awaited Haiku side-call via gB that
+// fails OPEN to the heuristic) and writes the level's effort onto a global the
+// wrapped XQ reads.
+//
+// -- Scope note --
+// XQ is CC's single effort resolver, used for the main loop AND for subagents /
+// side-calls that resolve effort the same way. The wrap applies the routed
+// effort wherever effort resolves with no explicit user pin, so a task's
+// subagents (on an effort-capable model) inherit the task's effort. Side-calls
+// on Haiku-class models are unaffected (Haiku does not take effort, so XQ
+// returns at its `!FR(e)` guard, before the wrap).
+//
+// -- Behavior --
+// pinPerTask (default true): keep the effort stable across a session. Heuristic
+// mode re-scores every prompt but only ESCALATES (never auto-downgrades), so a
+// session that revealed hard work keeps thinking hard; llm mode classifies once
+// and FREEZES that level until /clear (avoiding a classifier call per turn).
+// Set it false to re-rate every prompt - effort tracks each message up AND down
+// (and llm mode then fires the side-call every turn). `llm` mode awaits a
+// one-shot Haiku side-call at the task boundary and fails OPEN to the heuristic
+// on any error/timeout.
+//
+// -- Known limits (the /effort signal is value-based) --
+// CC keeps the persisted baseline and an in-session /effort in ONE app-state
+// slot, so we infer "user took manual control" by the fallback diverging from
+// the launch baseline. Consequences: (1) if the user /effort's to a value EQUAL
+// to their launch baseline, we can't distinguish it and keep driving (narrow:
+// re-pinning to your existing default). (2) The baseline is captured on the first
+// effort resolve - in practice a boot side-call, before any picker interaction;
+// only if the very first resolve were a /effort or /model picker preview (a path
+// reachable solely when the model's launch-pin gate is open) could it capture a
+// picker candidate. /clear re-captures a fresh baseline, recovering from both.
+
+import { debug } from '../utils';
+import { showDiff } from './index';
+import { ComplexityRouterConfig } from '../types';
+
+const ROUTER_MARKER = '__tweakccRouterClassify';
+
+// CC's gB structured side-call helper + km agent-context builder, captured from
+// the binary (both needed to fire the llm classifier correctly).
+interface ClassifierHelpers {
+  gB: string;
+  km: string;
+}
+
+// ---------------------------------------------------------------------------
+// Injected runtime (lives inside cli.js). All ASCII - no escaping needed.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the router runtime: per-session state, the synchronous heuristic
+ * scorer, the optional llm classifier, and the classify entry point. Config is
+ * baked in as literals (JSON.stringify for the array - F-84/F-88 class: a value
+ * can never break out of its literal).
+ *
+ * `helpers` is the captured gB/km pair for `llm` mode (or null, in which case
+ * the llm path degrades to the heuristic).
+ */
+const buildRuntime = (
+  config: ComplexityRouterConfig,
+  helpers: ClassifierHelpers | null
+): string => {
+  const efforts = config.levels.map(l => l.effort);
+  const mode = config.mode === 'llm' && helpers ? 'llm' : 'heuristic';
+  const efJson = JSON.stringify(efforts);
+  const pin = config.pinPerTask ? 'true' : 'false';
+
+  // The llm classifier is only emitted in llm mode with resolved gB/km. It
+  // mirrors CC's own structured gB callers exactly: the full options shape
+  // (agents/isNonInteractiveSession/hasAppendSystemPrompt/mcpTools/agentContext)
+  // is required - gB -> DWe -> Sql reads agentContext.agentType unconditionally,
+  // so omitting it throws on every call. gB pins model:HR() (the small-fast
+  // Haiku resolver) itself, so no model override is needed here.
+  const llmFn =
+    mode === 'llm' && helpers
+      ? `async function __tweakccRouterClassifyLlm(__t,__max){` +
+        // No minimum/maximum in the schema: structured outputs reject numeric
+        // constraints; the range is stated in the prompt and we clamp on read.
+        `var __schema={type:"object",properties:{level:{type:"integer",description:"task complexity, 0 (trivial) to "+__max+" (hardest)"}},required:["level"],additionalProperties:false};` +
+        `var __sys="You are a difficulty classifier for a coding agent. Read the user request and output an integer complexity level from 0 (trivial: a mechanical edit, rename, or search) to "+__max+" (the hardest: deep architecture, subtle concurrency/security, or large multi-file work). Output only the level. When uncertain, pick the higher level.";` +
+        `var __in=__t.length>4000?__t.slice(0,4000):__t;` +
+        `var __ac=new AbortController(),__to=setTimeout(function(){try{__ac.abort()}catch(__e){}},8000);` +
+        `try{var __res=await ${helpers.gB}({systemPrompt:[__sys],userPrompt:__in,outputFormat:{type:"json_schema",schema:__schema},signal:__ac.signal,options:{querySource:"route_complexity",agents:[],isNonInteractiveSession:!1,hasAppendSystemPrompt:!1,mcpTools:[],agentContext:${helpers.km}()}});` +
+        `return __tweakccRouterReadLevel(__res)}finally{clearTimeout(__to)}}` +
+        // Defensively pull an integer `level` out of gB's result, which is an
+        // assistant message: {message:{content:[{type:"text",text:"<json>"}]}}.
+        `function __tweakccRouterReadLevel(__r){try{` +
+        `if(__r==null)return null;` +
+        `if(typeof __r==="number")return __r;` +
+        `if(typeof __r.level==="number")return __r.level;` +
+        `var __c=(__r.message&&__r.message.content)||__r.content;` +
+        `var __x=typeof __r==="string"?__r:(Array.isArray(__c)&&__c[0]&&typeof __c[0].text==="string"?__c[0].text:(typeof __r.text==="string"?__r.text:""));` +
+        `if(__x){try{var __o=JSON.parse(__x);if(__o&&typeof __o.level==="number")return __o.level}catch(__e){}var __m=__x.match(/-?\\d+/);if(__m)return parseInt(__m[0],10)}` +
+        `return null}catch(__e){return null}}`
+      : '';
+
+  // Level computation, baked per mode:
+  //  - llm: classify once via gB (when pinned) and fail OPEN to the heuristic.
+  //  - heuristic: synchronous scorer; when pinned, escalate up only (monotonic),
+  //    never auto-downgrade (keeps a complex session thinking hard). With
+  //    pinPerTask off, the scorer's level is used directly each prompt.
+  const levelCompute =
+    mode === 'llm' && helpers
+      ? `var __max=__ef.length-1,__lv;` +
+        `if(__pin&&__st.level!==void 0){__lv=__st.level}` +
+        `else{try{__lv=await __tweakccRouterClassifyLlm(__text,__max)}catch(__e){__lv=null}` +
+        `if(__lv==null||__lv<0||__lv>__max)__lv=__tweakccRouterScore(__text,__max)}`
+      : `var __max=__ef.length-1,__lv=__tweakccRouterScore(__text,__max);` +
+        `if(__pin&&__st.level!==void 0&&__lv<__st.level)__lv=__st.level;`;
+
+  return (
+    `function __tweakccRouterState(){return globalThis.__tweakccRouter||(globalThis.__tweakccRouter={level:void 0,effort:void 0,baseline:void 0})}` +
+    // Synchronous heuristic difficulty scorer. Base level 1 (Standard); hard
+    // signals only ever RAISE the level, never lower it. Bias-to-escalate the
+    // ambiguous middle: the error cost is asymmetric (under-thinking a hard task
+    // is the dominant failure). Input is capped and every keyword regex uses
+    // bounded quantifiers, so it stays linear on adversarial single-line pastes.
+    `function __tweakccRouterScore(__t,__max){` +
+    `if(typeof __t!=="string"||!__t)return 1;` +
+    `if(__t.length>16000)__t=__t.slice(0,16000);` +
+    `var __s=__t.toLowerCase(),__n=0;` +
+    // strong signals (weight 2)
+    `if(/\\b(race condition|data race|deadlock|concurren|mutex|thread[- ]?saf|atomic)/.test(__s))__n+=2;` +
+    `if(/\\b(security|vulnerab|exploit|cve-|injection|xss|csrf|sandbox escape|priv(ilege)? escalat|auth\\w{0,40} bypass)/.test(__s))__n+=2;` +
+    `if(/\\b(refactor|re-?architect|architecture|redesign|rewrite|migrat|cross[- ]file|across (the )?(codebase|files|modules|repo))/.test(__s))__n+=2;` +
+    `if(/\\btraceback\\b|\\bexception\\b|\\bpanic:|\\bsegfault\\b|\\bcore dumped\\b|[\\w.$]{1,40}(error|exception):[^\\n]{0,120}\\d|\\bat [\\w$.]{1,80} ?\\([^\\n]{0,200}:\\d+:\\d+\\)/i.test(__t))__n+=2;` +
+    // medium signals (weight 1)
+    `if(/\\b(why (is|are|does|do|won'?t|doesn'?t|can'?t)|root cause|intermittent|flaky|heisenbug|hangs?|deadlocks?|leaks?)/.test(__s))__n+=1;` +
+    `if(/\\b(optimi[sz]e|performance|throughput|latency|complexity|algorithm|big[- ]?o|o\\(n)/.test(__s))__n+=1;` +
+    `if(/\\b(carefully|think (hard|deeply)|production|business[- ]critical|robust|edge cases?|correctness)/.test(__s))__n+=1;` +
+    `if(__t.length>1800)__n+=1;` +
+    `if((__t.match(/[\\w./-]{1,80}\\.[a-z]{1,5}\\b/gi)||[]).length>=3)__n+=1;` +
+    `if((__t.match(/\`\`\`/g)||[]).length>=4)__n+=1;` +
+    // explicit max-escalation phrases jump straight to the top tier
+    `var __l=1;` +
+    `if(/\\b(ultrathink|think as hard as|maximum effort|hardest possible|frontier model)/.test(__s))__l=__max;` +
+    `else{if(__n>=2)__l=2;if(__n>=5)__l=3}` +
+    `if(__l>__max)__l=__max;` +
+    `if(process.env.TWEAKCC_ROUTER_DEBUG)try{process.stderr.write("[tweakcc-router] heuristic signals="+__n+" -> level="+__l+"\\n")}catch(__e){}` +
+    `return __l}` +
+    llmFn +
+    // Classify the finalized user message and write the level's effort onto the
+    // global the wrapped effort resolver reads. The level-computation branch is
+    // baked per mode, so heuristic mode never references the llm helper.
+    `async function ${ROUTER_MARKER}(__text,__mode){try{` +
+    `var __ef=${efJson},__pin=${pin};` +
+    `if(!__ef||!__ef.length)return;` +
+    `var __st=__tweakccRouterState();` +
+    `if(typeof __text!=="string")return;` +
+    `var __tr=__text.replace(/^\\s+/,"");` +
+    // /clear (NOT /clear-screen) is a material context shift -> re-classify next.
+    // Also drop the captured effort baseline so the next resolve re-captures the
+    // CURRENT app-state effort as the fresh baseline: /clear is a clean slate, so
+    // the router resumes driving even if the user had /effort'd this session.
+    `if(/^\\/clear(\\s|$)/.test(__tr)){__st.level=void 0;__st.effort=void 0;__st.baseline=void 0;return}` +
+    `if(__tr.charAt(0)==="/")return;` + // other slash commands aren't tasks
+    `if(__mode!==void 0&&__mode!=="prompt")return;` + // only route prompt-mode submits
+    levelCompute +
+    `if(__lv<0)__lv=0;if(__lv>__max)__lv=__max;` +
+    `__st.level=__lv;__st.effort=__ef[__lv];` +
+    `if(process.env.TWEAKCC_ROUTER_DEBUG)try{process.stderr.write("[tweakcc-router] decision mode=${mode} level="+__lv+" effort="+__st.effort+" chars="+__text.length+"\\n")}catch(__e){}` +
+    `}catch(__e){}}`
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Splice 1: wrap the effort resolver XQ + prepend the runtime helpers.
+// ---------------------------------------------------------------------------
+const wrapEffortResolver = (
+  file: string,
+  config: ComplexityRouterConfig,
+  helpers: ClassifierHelpers | null
+): string | null => {
+  // function NAME(MODEL,FALLBACK){if(!FR(MODEL))return;let A=fUe(MODEL),B=Tbn(MODEL),ENV=mUe();
+  //   if(ENV===null)return A?B:void 0;let S=ENV??(A?B:void 0)??FALLBACK??B;
+  //   if(S==="max"&&!dUe(MODEL))return"high";if(S==="xhigh"&&!GRe(MODEL))return"high";return S}
+  // Captures: 1=prefix (through `=mUe();`), 2=MODEL, 3=FALLBACK, 4=ENV, 5=maxGuard, 6=xhighGuard.
+  const pattern =
+    /(function [$\w]+\(([$\w]+),([$\w]+)\)\{if\(![$\w]+\(\2\)\)return;let [$\w]+=[$\w]+\(\2\),[$\w]+=[$\w]+\(\2\),([$\w]+)=[$\w]+\(\);)if\(\4===null\)return [$\w]+\?[$\w]+:void 0;let [$\w]+=\4\?\?\([$\w]+\?[$\w]+:void 0\)\?\?\3\?\?[$\w]+;if\([$\w]+==="max"&&!([$\w]+)\(\2\)\)return"high";if\([$\w]+==="xhigh"&&!([$\w]+)\(\2\)\)return"high";return [$\w]+\}/;
+
+  const match = file.match(pattern);
+  if (!match || match.index === undefined) {
+    if (!file.includes('CLAUDE_CODE_EFFORT_LEVEL')) {
+      debug(
+        'patch: complexityRouter: effort resolver absent in this CC build - no-op'
+      );
+      return file;
+    }
+    console.error(
+      'patch: complexityRouter: failed to find effort resolver (XQ shape)'
+    );
+    return null;
+  }
+
+  const prefix = match[1];
+  const model = match[2];
+  const fallback = match[3];
+  const env = match[4];
+  const maxGuard = match[5];
+  const xhighGuard = match[6];
+
+  // Apply the router's effort, overriding the persisted effort baseline (CC's
+  // settings.effortLevel / the per-model default, which arrive as the app-state
+  // FALLBACK) but yielding to a deliberate user pin:
+  //   - ENV: CLAUDE_CODE_EFFORT_LEVEL set (env != null) -> always defer.
+  //   - in-session /effort: detected as the app-state FALLBACK diverging from the
+  //     launch baseline we capture on the first resolve. While the fallback still
+  //     equals the launch baseline (or is unset) the user has not touched effort
+  //     this session, so the router drives; once they /effort to a different
+  //     value the router yields for the rest of the session (until they set it
+  //     back, or /clear).
+  // This makes the router actually route for users who set a persistent
+  // effortLevel, without trampling an explicit in-session choice. Support guards
+  // (max/xhigh) are re-applied so an unsupported level still downgrades to "high".
+  const inject =
+    `var __st=__tweakccRouterState();` +
+    `if(__st.baseline===void 0)__st.baseline=(${fallback}==null?null:${fallback});` +
+    `let __twkRE=__st.effort;` +
+    `if(__twkRE&&${env}==null&&(${fallback}==null||${fallback}===__st.baseline)){` +
+    `if(__twkRE==="max"&&!${maxGuard}(${model}))__twkRE="high";` +
+    `if(__twkRE==="xhigh"&&!${xhighGuard}(${model}))__twkRE="high";` +
+    `return __twkRE}`;
+
+  const runtime = buildRuntime(config, helpers);
+  const replacement = runtime + prefix + inject + match[0].slice(prefix.length);
+
+  const start = match.index;
+  const end = start + match[0].length;
+  const newFile = file.slice(0, start) + replacement + file.slice(end);
+  showDiff(file, newFile, replacement, start, end);
+  return newFile;
+};
+
+// ---------------------------------------------------------------------------
+// Splice 2: call the classify hook from the submit handler.
+// ---------------------------------------------------------------------------
+const injectSubmitHook = (file: string): string | null => {
+  // if(E===null&&t!=="prompt")throw Error(`Mode: ${t} requires a string input.`);
+  // Captures: 1=text var (E), 2=mode var (t).
+  const pattern =
+    /if\(([$\w]+)===null&&([$\w]+)!=="prompt"\)throw Error\(`Mode: \$\{\2\} requires a string input\.`\);/;
+  const match = file.match(pattern);
+  if (!match || match.index === undefined) {
+    if (!file.includes('requires a string input.')) {
+      debug(
+        'patch: complexityRouter: submit handler absent in this CC build - no-op'
+      );
+      return file;
+    }
+    console.error(
+      'patch: complexityRouter: failed to find submit handler throw-guard'
+    );
+    return null;
+  }
+
+  const textVar = match[1];
+  const modeVar = match[2];
+  const call = `await ${ROUTER_MARKER}(${textVar},${modeVar});`;
+
+  const insertAt = match.index + match[0].length;
+  const newFile = file.slice(0, insertAt) + call + file.slice(insertAt);
+  showDiff(file, newFile, call, insertAt, insertAt);
+  return newFile;
+};
+
+// Locate CC's gB structured side-call helper (a one-shot, Haiku-pinned,
+// json-schema side-call) and the km agent-context builder for the llm
+// classifier. gB has a near-twin `Vpt` with an identical destructure signature,
+// so we anchor on the segment unique to gB: it pins `model:<fn>(),enablePromptCaching:`
+// (Vpt has no `model:` field). km is `function NAME(){return{agentType:"main",agentId:<fn>()}}`.
+const findClassifierHelpers = (file: string): ClassifierHelpers | null => {
+  const gb = file.match(
+    /async function ([$\w]+)\(\{systemPrompt:[$\w]+=[$\w]+\(\[\]\),userPrompt:[$\w]+,outputFormat:[$\w]+,signal:[$\w]+,options:[$\w]+\}\)\{return\(await [$\w]+\([\s\S]{0,500}?,model:[$\w]+\(\),enablePromptCaching:/
+  );
+  const km = file.match(
+    /function ([$\w]+)\(\)\{return\{agentType:"main",agentId:[$\w]+\(\)\}\}/
+  );
+  if (gb && km) return { gB: gb[1], km: km[1] };
+  return null;
+};
+
+export const writeComplexityRouter = (
+  oldFile: string,
+  config: ComplexityRouterConfig
+): string | null => {
+  // Idempotency: already patched.
+  if (oldFile.includes(ROUTER_MARKER)) {
+    debug('patch: complexityRouter: already patched - skipping');
+    return oldFile;
+  }
+
+  let helpers: ClassifierHelpers | null = null;
+  if (config.mode === 'llm') {
+    helpers = findClassifierHelpers(oldFile);
+    if (!helpers) {
+      console.warn(
+        'patch: complexityRouter: llm mode requested but the gB/km side-call ' +
+          'helpers were not found - falling back to the heuristic classifier'
+      );
+    }
+  }
+
+  const afterResolver = wrapEffortResolver(oldFile, config, helpers);
+  if (afterResolver === null) return null;
+  // Graceful no-op (resolver absent) returns the file unchanged: nothing to hook.
+  if (afterResolver === oldFile) return oldFile;
+
+  const afterHook = injectSubmitHook(afterResolver);
+  if (afterHook === null) return null;
+  // All-or-nothing: if the submit handler is absent (injectSubmitHook returned
+  // the file unchanged), don't ship the resolver wrap + runtime with nothing to
+  // populate the global - that would leave the wrap permanently inert plus dead
+  // injected code in cli.js. Revert the whole patch instead.
+  if (afterHook === afterResolver) {
+    debug(
+      'patch: complexityRouter: submit handler absent - reverting the resolver ' +
+        'wrap too (all-or-nothing no-op)'
+    );
+    return oldFile;
+  }
+
+  return afterHook;
+};

--- a/src/patches/complexityRouter.ts
+++ b/src/patches/complexityRouter.ts
@@ -77,6 +77,12 @@
 // only if the very first resolve were a /effort or /model picker preview (a path
 // reachable solely when the model's launch-pin gate is open) could it capture a
 // picker candidate. /clear re-captures a fresh baseline, recovering from both.
+//
+// -- Observability (no extra patch needed) --
+// CC's statusline-command input JSON builds `effort.level` via `sO -> eZ` (the
+// resolver we wrap: `sO(e,t)=Gfe(eZ(e,t)??"high")`), so the routed effort already
+// rides into a custom statusline's stdin - a script can read `.effort.level` to
+// render a badge. `TWEAKCC_ROUTER_DEBUG=1` also logs each decision to stderr.
 
 import { debug } from '../utils';
 import { showDiff } from './index';

--- a/src/patches/complexityRouter.ts
+++ b/src/patches/complexityRouter.ts
@@ -158,11 +158,13 @@ const buildRuntime = (
 
   return (
     `function __tweakccRouterState(){return globalThis.__tweakccRouter||(globalThis.__tweakccRouter={level:void 0,effort:void 0,baseline:void 0})}` +
-    // Synchronous heuristic difficulty scorer. Base level 1 (Standard); hard
-    // signals only ever RAISE the level, never lower it. Bias-to-escalate the
-    // ambiguous middle: the error cost is asymmetric (under-thinking a hard task
-    // is the dominant failure). Input is capped and every keyword regex uses
-    // bounded quantifiers, so it stays linear on adversarial single-line pastes.
+    // Synchronous heuristic difficulty scorer. Default level 1 (Standard);
+    // confident-trivial work routes DOWN to 0 (low) - the cost win - while
+    // accumulated hard signals escalate UP. Bias-to-escalate the ambiguous middle:
+    // the error cost is asymmetric (under-thinking a hard task is the dominant
+    // failure), so only an explicit mechanical verb with ZERO hard signals earns
+    // low; everything uncertain stays at medium. Input is capped and every keyword
+    // regex uses bounded quantifiers, so it stays linear on adversarial pastes.
     `function __tweakccRouterScore(__t,__max){` +
     `if(typeof __t!=="string"||!__t)return 1;` +
     `if(__t.length>16000)__t=__t.slice(0,16000);` +
@@ -179,11 +181,18 @@ const buildRuntime = (
     `if(__t.length>1800)__n+=1;` +
     `if((__t.match(/[\\w./-]{1,80}\\.[a-z]{1,5}\\b/gi)||[]).length>=3)__n+=1;` +
     `if((__t.match(/\`\`\`/g)||[]).length>=4)__n+=1;` +
-    // explicit max-escalation phrases jump straight to the top tier
-    `var __l=1;` +
+    // Decide the level: confident-trivial work (an explicit mechanical verb with
+    // ZERO hard signals) routes DOWN to low (0); ambiguous work stays at the
+    // medium default (1); accumulated signals escalate up; explicit max-effort
+    // phrases jump straight to the top tier.
+    `var __triv=__n===0&&/\\b(rename|fix (?:the |a )?typos?|typos?|reformat|run (?:the )?prettier|prettier|gofmt|sort (?:the )?imports|bump (?:the )?version|add (?:a )?(?:comment|docstring|jsdoc)|remove (?:the |a )?(?:comment|console\\.log|unused import|debug (?:log|statement)))\\b/.test(__s);` +
+    `var __l;` +
     `if(/\\b(ultrathink|think as hard as|maximum effort|hardest possible|frontier model)/.test(__s))__l=__max;` +
-    `else{if(__n>=2)__l=2;if(__n>=5)__l=3}` +
-    `if(__l>__max)__l=__max;` +
+    `else if(__n>=5)__l=3;` +
+    `else if(__n>=2)__l=2;` +
+    `else if(__triv)__l=0;` +
+    `else __l=1;` +
+    `if(__l<0)__l=0;if(__l>__max)__l=__max;` +
     `if(process.env.TWEAKCC_ROUTER_DEBUG)try{process.stderr.write("[tweakcc-router] heuristic signals="+__n+" -> level="+__l+"\\n")}catch(__e){}` +
     `return __l}` +
     llmFn +

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -94,6 +94,7 @@ import { writeAllowCustomAgentModels } from './allowCustomAgentModels';
 import { writeMaxEffortDefault } from './maxEffortDefault';
 import { writeAutonomousOperationAllModels } from './autonomousOperationAllModels';
 import { writeAutoModeClassifierModel } from './autoModeClassifierModel';
+import { writeComplexityRouter } from './complexityRouter';
 import { writeVoiceMode } from './voiceMode';
 import { writeChannelsMode } from './channelsMode';
 import { writeClearScreen } from './clearScreen';
@@ -447,6 +448,13 @@ const PATCH_DEFINITIONS = [
       'Pin auto-mode bash safety classifier to Sonnet 4.6 or Haiku 4.5 instead of the user main-loop model (avoids Opus 4.7 congestion denying tool calls)',
   },
   // Features
+  {
+    id: 'complexity-router',
+    name: '[EXPERIMENTAL] Complexity effort router',
+    group: PatchGroup.FEATURES,
+    description:
+      'Auto-route reasoning effort (thinking depth) by task complexity: routine work runs at low effort, the hardest at max. Rides on your current model - no model switch, no prompt-cache churn. While on it drives effort, overriding your saved effortLevel default; an in-session /effort or CLAUDE_CODE_EFFORT_LEVEL still wins. Heuristic by default; optional Haiku-classifier (llm) mode fails back to the heuristic. Off by default.',
+  },
   {
     id: 'allow-custom-agent-models',
     name: 'Allow custom agent models',
@@ -1082,6 +1090,14 @@ export const applyCustomization = async (
         'default',
     },
     // Features
+    'complexity-router': {
+      fn: c =>
+        writeComplexityRouter(
+          c,
+          config.settings.complexityRouter ?? DEFAULT_SETTINGS.complexityRouter!
+        ),
+      condition: !!config.settings.complexityRouter?.enabled,
+    },
     'allow-custom-agent-models': {
       fn: c => writeAllowCustomAgentModels(c),
       condition: !!config.settings.misc?.allowCustomAgentModels,

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -1091,12 +1091,8 @@ export const applyCustomization = async (
     },
     // Features
     'complexity-router': {
-      fn: c =>
-        writeComplexityRouter(
-          c,
-          config.settings.complexityRouter ?? DEFAULT_SETTINGS.complexityRouter!
-        ),
-      condition: !!config.settings.complexityRouter?.enabled,
+      fn: c => writeComplexityRouter(c, config.settings.complexityRouter),
+      condition: config.settings.complexityRouter.enabled,
     },
     'allow-custom-agent-models': {
       fn: c => writeAllowCustomAgentModels(c),

--- a/src/tests/config.test.ts
+++ b/src/tests/config.test.ts
@@ -227,6 +227,80 @@ describe('config.ts', () => {
         expect.stringMatching(/config\.json\.corrupt-/)
       );
     });
+
+    describe('complexityRouter.levels normalization', () => {
+      const mkConfig = (complexityRouter: unknown) =>
+        JSON.stringify({
+          ccVersion: '1.0.0',
+          ccInstallationPath: null,
+          lastModified: '2024-01-01',
+          changesApplied: true,
+          settings: { ...DEFAULT_SETTINGS, complexityRouter },
+        });
+      const defLevels = DEFAULT_SETTINGS.complexityRouter.levels;
+
+      it('backfills an empty levels array to the defaults (no silent no-op)', async () => {
+        vi.spyOn(fs, 'readFile').mockResolvedValue(
+          mkConfig({ enabled: true, levels: [] })
+        );
+        const result = await readConfigFile();
+        expect(result.settings.complexityRouter.levels).toEqual(defLevels);
+      });
+
+      it('falls back to defaults for a non-array levels (no .map crash)', async () => {
+        vi.spyOn(fs, 'readFile').mockResolvedValue(
+          mkConfig({ enabled: true, levels: 'garbage' })
+        );
+        const result = await readConfigFile();
+        expect(result.settings.complexityRouter.levels).toEqual(defLevels);
+      });
+
+      it('coerces a garbage or falsy effort to the per-index default', async () => {
+        vi.spyOn(fs, 'readFile').mockResolvedValue(
+          mkConfig({
+            enabled: true,
+            levels: [
+              { id: 'routine', label: 'R', help: '', effort: 'SUPERHIGH' },
+              { id: 'standard', label: 'S', help: '', effort: '' },
+            ],
+          })
+        );
+        const result = await readConfigFile();
+        const lv = result.settings.complexityRouter.levels;
+        expect(lv[0].effort).toBe(defLevels[0].effort);
+        expect(lv[1].effort).toBe(defLevels[1].effort);
+      });
+
+      it('preserves a valid custom effort', async () => {
+        vi.spyOn(fs, 'readFile').mockResolvedValue(
+          mkConfig({
+            enabled: true,
+            levels: [{ id: 'routine', label: 'R', help: '', effort: 'max' }],
+          })
+        );
+        const result = await readConfigFile();
+        expect(result.settings.complexityRouter.levels[0].effort).toBe('max');
+      });
+
+      it('synthesizes unique ids for overflow levels (no duplicate React keys)', async () => {
+        vi.spyOn(fs, 'readFile').mockResolvedValue(
+          mkConfig({
+            enabled: true,
+            levels: [
+              { id: 'a', label: 'A', help: '', effort: 'low' },
+              { id: 'b', label: 'B', help: '', effort: 'medium' },
+              { id: 'c', label: 'C', help: '', effort: 'high' },
+              { id: 'd', label: 'D', help: '', effort: 'max' },
+              { label: 'E', help: '', effort: 'max' },
+              { label: 'F', help: '', effort: 'max' },
+            ],
+          })
+        );
+        const result = await readConfigFile();
+        const ids = result.settings.complexityRouter.levels.map(l => l.id);
+        expect(new Set(ids).size).toBe(ids.length);
+      });
+    });
   });
 
   describe('updateConfigFile', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,6 +175,34 @@ export interface SubagentModelsConfig {
   generalPurpose: string | null;
 }
 
+// [EXPERIMENTAL] Complexity effort router.
+//
+// Classifies how hard a task is into an ordinal level and pins the session's
+// reasoning-effort (thinking) level accordingly: trivial work runs at low
+// effort (fast, cheap), the hardest work runs at max effort. It rides on
+// whatever model the user is already on (Opus 4.8 by default), so it is a pure
+// thinking-depth dial - no model switch, no prompt-cache churn. Off by default.
+export type RouterClassifierMode = 'heuristic' | 'llm';
+
+// Claude Code's reasoning-effort levels (the `effort` API param / `/effort`).
+// Opus 4.8 supports all five; the per-level support guard downgrades an
+// unsupported level to 'high' at resolve time.
+export type RouterEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+export interface RouterLevel {
+  id: string; // stable key (e.g. 'routine'); used for reset-to-default
+  label: string; // short display name (e.g. 'Standard')
+  help: string; // one-line description of when this level applies
+  effort: RouterEffort; // the reasoning-effort level this complexity tier maps to
+}
+
+export interface ComplexityRouterConfig {
+  enabled: boolean;
+  mode: RouterClassifierMode; // default 'heuristic'
+  pinPerTask: boolean; // default TRUE - classify once per task, keep for the session (stable, only escalates)
+  levels: RouterLevel[]; // ordinal complexity level -> effort map (index 0 = easiest)
+}
+
 export interface Settings {
   themes: Theme[];
   thinkingVerbs: ThinkingVerbsConfig;
@@ -186,6 +214,7 @@ export interface Settings {
   defaultToolset: string | null;
   planModeToolset: string | null;
   subagentModels: SubagentModelsConfig;
+  complexityRouter?: ComplexityRouterConfig;
   inputPatternHighlighters: InputPatternHighlighter[];
   inputPatternHighlightersTestText: string; // Global test text for previewing highlighters
   claudeMdAltNames: string[] | null;
@@ -249,6 +278,7 @@ export enum MainMenuItem {
   MISC = 'Misc',
   TOOLSETS = 'Toolsets',
   SUBAGENT_MODELS = 'Subagent models',
+  COMPLEXITY_ROUTER = 'Complexity effort router [experimental]',
   CLAUDE_MD_ALT_NAMES = 'CLAUDE.md alternative names',
   SYSTEM_REMINDERS = 'System reminders (injection lobotomy)',
   SKILLS = 'Skills (per-skill on/name-only/user-invocable/off)',

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,7 +190,7 @@ export type RouterClassifierMode = 'heuristic' | 'llm';
 export type RouterEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
 export interface RouterLevel {
-  id: string; // stable key (e.g. 'routine'); used for reset-to-default
+  id: string; // stable key (e.g. 'routine'); used as the React list key in the TUI
   label: string; // short display name (e.g. 'Standard')
   help: string; // one-line description of when this level applies
   effort: RouterEffort; // the reasoning-effort level this complexity tier maps to
@@ -214,7 +214,9 @@ export interface Settings {
   defaultToolset: string | null;
   planModeToolset: string | null;
   subagentModels: SubagentModelsConfig;
-  complexityRouter?: ComplexityRouterConfig;
+  // Non-optional like subagentModels (its analog): DEFAULT_SETTINGS always
+  // provides it and normalizeConfig backfills it via deepMergeWithDefaults.
+  complexityRouter: ComplexityRouterConfig;
   inputPatternHighlighters: InputPatternHighlighter[];
   inputPatternHighlightersTestText: string; // Global test text for previewing highlighters
   claudeMdAltNames: string[] | null;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -9,6 +9,7 @@ import { InputPatternHighlightersView } from './components/InputPatternHighlight
 import { MiscView } from './components/MiscView';
 import { ToolsetsView } from './components/ToolsetsView';
 import { SubagentModelsView } from './components/SubagentModelsView';
+import { ComplexityRouterView } from './components/ComplexityRouterView';
 import { ClaudeMdAltNamesView } from './components/ClaudeMdAltNamesView';
 import { SystemRemindersView } from './components/SystemRemindersView';
 import { SkillsView } from './components/SkillsView';
@@ -137,6 +138,7 @@ Please reapply your changes by running \`${invocationCommand} --apply\`.`,
       case MainMenuItem.MISC:
       case MainMenuItem.TOOLSETS:
       case MainMenuItem.SUBAGENT_MODELS:
+      case MainMenuItem.COMPLEXITY_ROUTER:
       case MainMenuItem.CLAUDE_MD_ALT_NAMES:
       case MainMenuItem.SYSTEM_REMINDERS:
       case MainMenuItem.SKILLS:
@@ -230,6 +232,8 @@ Please reapply your changes by running \`${invocationCommand} --apply\`.`,
           <ToolsetsView onBack={handleBack} />
         ) : currentView === MainMenuItem.SUBAGENT_MODELS ? (
           <SubagentModelsView onBack={handleBack} />
+        ) : currentView === MainMenuItem.COMPLEXITY_ROUTER ? (
+          <ComplexityRouterView onBack={handleBack} />
         ) : currentView === MainMenuItem.CLAUDE_MD_ALT_NAMES ? (
           <ClaudeMdAltNamesView onBack={handleBack} />
         ) : currentView === MainMenuItem.SYSTEM_REMINDERS ? (

--- a/src/ui/components/ComplexityRouterView.tsx
+++ b/src/ui/components/ComplexityRouterView.tsx
@@ -27,8 +27,7 @@ const SETTING_ROWS: SettingRow[] = ['enabled', 'mode', 'pinPerTask'];
 
 type SubPicker = { levelIndex: number } | null;
 
-const defaultRouter =
-  DEFAULT_SETTINGS.complexityRouter as ComplexityRouterConfig;
+const defaultRouter = DEFAULT_SETTINGS.complexityRouter;
 
 export function ComplexityRouterView({ onBack }: ComplexityRouterViewProps) {
   const { settings, updateSettings } = useContext(SettingsContext);

--- a/src/ui/components/ComplexityRouterView.tsx
+++ b/src/ui/components/ComplexityRouterView.tsx
@@ -226,9 +226,9 @@ export function ComplexityRouterView({ onBack }: ComplexityRouterViewProps) {
           CLAUDE_CODE_EFFORT_LEVEL always wins.
         </Text>
         <Text dimColor>
-          See it: the routed effort rides into the JSON CC pipes to a custom
-          statusline as .effort.level - read that in your statusline command to
-          show a badge (e.g. ◈ max). TWEAKCC_ROUTER_DEBUG=1 also logs decisions.
+          See it: Claude Code&apos;s working indicator already shows it live -
+          e.g. &quot;thinking with max effort&quot; reflects the routed level.
+          TWEAKCC_ROUTER_DEBUG=1 also logs each decision.
         </Text>
         <Text dimColor>
           ↑↓ navigate · enter/space change · x reset level · esc back

--- a/src/ui/components/ComplexityRouterView.tsx
+++ b/src/ui/components/ComplexityRouterView.tsx
@@ -1,0 +1,260 @@
+import { Box, Text, useInput } from 'ink';
+import { useContext, useState } from 'react';
+import { SettingsContext } from '../App';
+import Header from './Header';
+import { DEFAULT_SETTINGS } from '../../defaultSettings';
+import {
+  ComplexityRouterConfig,
+  RouterClassifierMode,
+  RouterEffort,
+} from '../../types';
+
+interface ComplexityRouterViewProps {
+  onBack: () => void;
+}
+
+const EFFORT_OPTIONS: { value: RouterEffort; blurb: string }[] = [
+  { value: 'low', blurb: 'Fastest, cheapest - minimal reasoning' },
+  { value: 'medium', blurb: 'Balanced reasoning' },
+  { value: 'high', blurb: 'Deep reasoning' },
+  { value: 'xhigh', blurb: 'Very deep reasoning' },
+  { value: 'max', blurb: 'Maximum reasoning - slowest, priciest' },
+];
+
+// Settings rows that live above the per-level list.
+type SettingRow = 'enabled' | 'mode' | 'pinPerTask';
+const SETTING_ROWS: SettingRow[] = ['enabled', 'mode', 'pinPerTask'];
+
+type SubPicker = { levelIndex: number } | null;
+
+const defaultRouter =
+  DEFAULT_SETTINGS.complexityRouter as ComplexityRouterConfig;
+
+export function ComplexityRouterView({ onBack }: ComplexityRouterViewProps) {
+  const { settings, updateSettings } = useContext(SettingsContext);
+
+  // Always read through a fully-defaulted copy so an older config without the
+  // complexityRouter block (or missing a field) renders sane values.
+  const router: ComplexityRouterConfig = {
+    ...defaultRouter,
+    ...(settings.complexityRouter ?? {}),
+    levels:
+      settings.complexityRouter?.levels &&
+      settings.complexityRouter.levels.length > 0
+        ? settings.complexityRouter.levels
+        : defaultRouter.levels,
+  };
+
+  // Flat navigable list: the setting rows, then one row per level.
+  const totalRows = SETTING_ROWS.length + router.levels.length;
+  const [focusIndex, setFocusIndex] = useState(0);
+  const [picker, setPicker] = useState<SubPicker>(null);
+  const [pickerIndex, setPickerIndex] = useState(0);
+
+  const mutate = (fn: (r: ComplexityRouterConfig) => void) => {
+    updateSettings(s => {
+      const current: ComplexityRouterConfig = {
+        ...defaultRouter,
+        ...(s.complexityRouter ?? {}),
+        // deep-copy levels so we never mutate the default array in place
+        levels: (s.complexityRouter?.levels &&
+        s.complexityRouter.levels.length > 0
+          ? s.complexityRouter.levels
+          : defaultRouter.levels
+        ).map(l => ({ ...l })),
+      };
+      fn(current);
+      s.complexityRouter = current;
+    });
+  };
+
+  useInput((input, key) => {
+    // ---- effort sub-picker mode ----
+    if (picker) {
+      if (key.escape) {
+        setPicker(null);
+        return;
+      }
+      if (key.upArrow) {
+        setPickerIndex(p => (p > 0 ? p - 1 : EFFORT_OPTIONS.length - 1));
+        return;
+      }
+      if (key.downArrow) {
+        setPickerIndex(p => (p < EFFORT_OPTIONS.length - 1 ? p + 1 : 0));
+        return;
+      }
+      if (key.return) {
+        const value = EFFORT_OPTIONS[pickerIndex].value;
+        const levelIndex = picker.levelIndex;
+        mutate(r => {
+          if (r.levels[levelIndex]) r.levels[levelIndex].effort = value;
+        });
+        setPicker(null);
+      }
+      return;
+    }
+
+    // ---- main list mode ----
+    if (key.escape) {
+      onBack();
+      return;
+    }
+    if (key.upArrow) {
+      setFocusIndex(i => (i > 0 ? i - 1 : totalRows - 1));
+      return;
+    }
+    if (key.downArrow) {
+      setFocusIndex(i => (i < totalRows - 1 ? i + 1 : 0));
+      return;
+    }
+
+    const isSettingRow = focusIndex < SETTING_ROWS.length;
+    const levelIndex = focusIndex - SETTING_ROWS.length;
+
+    // 'x' resets a focused level to its default effort.
+    if (input === 'x' && !isSettingRow) {
+      const def = defaultRouter.levels[levelIndex];
+      if (def) {
+        mutate(r => {
+          if (r.levels[levelIndex]) r.levels[levelIndex].effort = def.effort;
+        });
+      }
+      return;
+    }
+
+    if (input === ' ' || key.return) {
+      if (isSettingRow) {
+        const row = SETTING_ROWS[focusIndex];
+        if (row === 'enabled') {
+          mutate(r => {
+            r.enabled = !r.enabled;
+          });
+        } else if (row === 'mode') {
+          mutate(r => {
+            const next: RouterClassifierMode =
+              r.mode === 'heuristic' ? 'llm' : 'heuristic';
+            r.mode = next;
+          });
+        } else if (row === 'pinPerTask') {
+          mutate(r => {
+            r.pinPerTask = !r.pinPerTask;
+          });
+        }
+      } else {
+        const idx = EFFORT_OPTIONS.findIndex(
+          e => e.value === router.levels[levelIndex]?.effort
+        );
+        setPickerIndex(idx >= 0 ? idx : 0);
+        setPicker({ levelIndex });
+      }
+    }
+  });
+
+  // ---------- effort sub-picker render ----------
+  if (picker) {
+    return (
+      <Box flexDirection="column">
+        <Box marginBottom={1}>
+          <Header>
+            Select effort for &quot;{router.levels[picker.levelIndex]?.label}
+            &quot;
+          </Header>
+        </Box>
+        {EFFORT_OPTIONS.map((option, index) => {
+          const isSelected = index === pickerIndex;
+          return (
+            <Box key={index}>
+              <Text color={isSelected ? 'cyan' : undefined}>
+                {isSelected ? '❯ ' : '  '}
+                {option.value}
+                <Text dimColor> - {option.blurb}</Text>
+              </Text>
+            </Box>
+          );
+        })}
+      </Box>
+    );
+  }
+
+  // ---------- main render ----------
+  const renderSettingRow = (row: SettingRow, index: number) => {
+    const isSelected = index === focusIndex;
+    let label: string;
+    let value: string;
+    if (row === 'enabled') {
+      label = 'Enabled';
+      value = router.enabled ? 'on' : 'off';
+    } else if (row === 'mode') {
+      label = 'Classifier mode';
+      value = router.mode;
+    } else {
+      label = 'Pin per task';
+      value = router.pinPerTask ? 'on' : 'off';
+    }
+    return (
+      <Box key={row}>
+        <Text color={isSelected ? 'cyan' : undefined}>
+          {isSelected ? '❯ ' : '  '}
+          {label}: <Text color="green">{value}</Text>
+        </Text>
+      </Box>
+    );
+  };
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Header>Complexity Effort Router [experimental]</Header>
+      </Box>
+
+      <Box marginBottom={1} flexDirection="column">
+        <Text dimColor>
+          Classifies each task by difficulty and sets the reasoning-effort
+          (thinking) level to match - low effort for routine work, max for the
+          hardest. Runs on your current model (no model switch, no prompt-cache
+          churn). Off by default.
+        </Text>
+        <Text dimColor>
+          heuristic mode is instant; llm mode adds a one-shot Haiku classifier
+          call at the task boundary (fails back to heuristic). pin per task
+          keeps effort stable for a session (only escalates); turn it off to
+          re-rate every prompt.
+        </Text>
+        <Text dimColor>
+          While on, the router drives effort, overriding your saved effortLevel.
+          An in-session /effort takes back manual control for that session, and
+          CLAUDE_CODE_EFFORT_LEVEL always wins.
+        </Text>
+        <Text dimColor>
+          ↑↓ navigate · enter/space change · x reset level · esc back
+        </Text>
+      </Box>
+
+      {SETTING_ROWS.map((row, i) => renderSettingRow(row, i))}
+
+      <Box marginTop={1} marginBottom={1}>
+        <Text bold>Complexity levels and their effort</Text>
+      </Box>
+
+      {router.levels.map((level, i) => {
+        const index = SETTING_ROWS.length + i;
+        const isSelected = index === focusIndex;
+        return (
+          <Box key={level.id} flexDirection="column" marginBottom={1}>
+            <Box>
+              <Text color={isSelected ? 'cyan' : undefined}>
+                {isSelected ? '❯ ' : '  '}
+                <Text bold>{level.label}</Text>
+                {'  '}
+                <Text color="green">{level.effort}</Text>
+              </Text>
+            </Box>
+            <Box marginLeft={4}>
+              <Text dimColor>{level.help}</Text>
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/ui/components/ComplexityRouterView.tsx
+++ b/src/ui/components/ComplexityRouterView.tsx
@@ -226,6 +226,11 @@ export function ComplexityRouterView({ onBack }: ComplexityRouterViewProps) {
           CLAUDE_CODE_EFFORT_LEVEL always wins.
         </Text>
         <Text dimColor>
+          See it: the routed effort rides into the JSON CC pipes to a custom
+          statusline as .effort.level - read that in your statusline command to
+          show a badge (e.g. ◈ max). TWEAKCC_ROUTER_DEBUG=1 also logs decisions.
+        </Text>
+        <Text dimColor>
           ↑↓ navigate · enter/space change · x reset level · esc back
         </Text>
       </Box>

--- a/src/ui/components/MainMenu.tsx
+++ b/src/ui/components/MainMenu.tsx
@@ -37,6 +37,10 @@ const baseMenuItems: SelectItem[] = [
     desc: 'Configure which Claude model each subagent uses (Plan, Explore, etc.)',
   },
   {
+    name: MainMenuItem.COMPLEXITY_ROUTER,
+    desc: '[EXPERIMENTAL] Auto-route reasoning effort by task complexity (routine=low ... hardest=max)',
+  },
+  {
     name: MainMenuItem.CLAUDE_MD_ALT_NAMES,
     desc: 'Configure alternative filenames for CLAUDE.md (e.g., AGENTS.md)',
   },


### PR DESCRIPTION
## [EXPERIMENTAL] Complexity effort router

Auto-routes the **reasoning effort** (thinking depth) per task complexity, on whatever model you're already on (Opus 4.8) — routine work runs at `low`, the hardest at `max`. A pure thinking-depth dial: **no model switch**. Off by default (`settings.complexityRouter.enabled`).

> V1 routes *effort*, not *model* (Fable is disabled, and Opus-4.8-low already beats Sonnet-high on DeepSWE). `RouterLevel` keeps a general shape for a future model-router V2.

### How it works
- **Effort-resolver wrap.** CC resolves every turn's effort through one function (`eZ` in 2.1.187); its result becomes `output_config.effort`. The patch wraps it to return the router's chosen effort. Anchors capture the minified names at apply time (verified auto-adapting 2.1.186→2.1.187).
- **Classify hook.** Splices the submit handler at the stable `` `requires a string input.` `` throw and classifies each task: a synchronous keyword **heuristic** (default) or an opt-in one-shot **Haiku classifier** (`llm` mode) that fails open.
- **Bidirectional routing.** Escalates hard work up **and** routes confidently-trivial work (rename / fix typo / bump version / add comment …, zero hard signals) **down to `low`** — so the cost-saving direction fires by default. Ambiguous work stays `medium`.
- **Precedence.** Overrides your persisted `settings.effortLevel` baseline, but yields to `CLAUDE_CODE_EFFORT_LEVEL` and to an in-session `/effort` (detected as the app-state effort diverging from the launch baseline; `/clear` resumes). All-or-nothing patch.
- **Cache.** Changing effort is **not** a prompt-cache invalidator → routing per task adds **no cache cost**.

### Visibility — automatic, no setup
Because the router wraps the effort resolver, **CC's own working indicator already shows the routed effort** — e.g. `✶ Crafting… (· thinking with max effort)` — for *every* user, on every thinking turn, with no patch and no custom statusline (CC builds that line via `fet → eZ`, the wrapped resolver). `TWEAKCC_ROUTER_DEBUG=1` logs each decision. (The statusline-command JSON also carries it as `.effort.level` via `sO → eZ`, if you want an always-on custom badge — but the spinner already covers it.)

### Config + UI
`settings.complexityRouter`: `enabled`, `mode`, `pinPerTask`, per-level `effort` map. TUI editor → **Complexity effort router [experimental]**.

### Testing
- `pnpm lint` + **755 tests** (execute the injected scorer / classify / llm / wrapped-resolver + ReDoS guard + precedence + low-routing + `/clear`-resume + all-or-nothing) + `pnpm build`. Three deep-review rounds.
- **Live on CC 2.1.187** (wire via a logging proxy; spinner + statusline observed): routine→`low`/`medium`, hard→`max` over a pinned `xhigh`; `CLAUDE_CODE_EFFORT_LEVEL=low`→`low` (yields); spinner live-read `thinking with max effort` on a routed hard turn.

Off by default; experimental.
