### PR TITLE
Announce behavioral patches before applying; mark which are default-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,28 +72,30 @@ Two of those are worth calling out, and both ship off by default. **fff-first Ba
 
 <br>
 
+Each patch is tagged with how it behaves on `--apply`: **`[default on]`** applies unless you set its config flag to `false`, **`[always]`** applies unconditionally with no toggle, **`[opt-in]`** applies only if you turn it on. Patches that change model-facing behavior are marked **on by default** below — `--apply` activates them even if you never selected them, so review these before applying.
+
 **Memory & context**
 
-- `dream-mode` — `/dream` plus automatic memory consolidation
-- `lean-memory-types` — a trimmed memory-type taxonomy
-- `claudemd-context-once-per-conversation` — inject CLAUDE.md and context once per conversation, not every turn
+- `dream-mode` **`[default on]`** — `/dream` plus automatic memory consolidation
+- `lean-memory-types` **`[opt-in]`** — a trimmed memory-type taxonomy
+- `claudemd-context-once-per-conversation` **`[default on]`** — inject CLAUDE.md and context once per conversation, not every turn (rewrites how CLAUDE.md reaches the model)
 
 **Reasoning**
 
-- `max-effort-default` — Opus defaults to max reasoning effort
-- `complexity-router` — route reasoning effort by task difficulty _(experimental)_
+- `max-effort-default` **`[opt-in]`** — Opus defaults to max reasoning effort
+- `complexity-router` **`[opt-in]`** — route reasoning effort by task difficulty _(experimental)_
 
 **Search**
 
-- `swap-ripgrep-for-fff` — fff-backed grep, find, and rg _(experimental)_
+- `swap-ripgrep-for-fff` **`[opt-in]`** — fff-backed grep, find, and rg _(experimental)_
 
 **Correctness & noise**
 
-- `fix-rewind-summary-header` — an honest rewind / compaction summary header
-- `fix-summarize-from-here` — "summarize from here" starts at the rewind point, not the top
-- `strip-empty-system-reminders` — drop the empty `<system-reminder>` blocks left after empty tool output
-- `read-default-lines` — an env-gated cap on the default `Read` line count
-- `suppress-deferred-tools` — drop the deferred-tools announcement
+- `fix-rewind-summary-header` **`[default on]`** — an honest rewind / compaction summary header
+- `fix-summarize-from-here` **`[default on]`** — "summarize from here" starts at the rewind point, not the top
+- `strip-empty-system-reminders` **`[always]`** — drop the empty `<system-reminder>` blocks left after empty tool output
+- `read-default-lines` **`[always]`** — an env-gated cap on the default `Read` line count
+- `suppress-deferred-tools` **`[opt-in]`** — drop the deferred-tools announcement
 
 **Models & prompts**
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Each patch is tagged with how it behaves on `--apply`: **`[default on]`** applie
 
 **Models & prompts**
 
-- `autonomous-operation-all-models` — apply the Fable/Mythos autonomous prompt set to every model
-- `auto-mode-classifier-model` — pin the auto-mode safety classifier to a cheaper model
+- `autonomous-operation-all-models` **`[opt-in]`** — apply the Fable/Mythos autonomous prompt set to every model
+- `auto-mode-classifier-model` **`[opt-in]`** — pin the auto-mode safety classifier to a cheaper model
 
 </details>
 


### PR DESCRIPTION
Following up on #21 (the symlink-nesting fix — thanks for merging). This is a transparency concern about `--apply`, with a clean-room demonstration. The fork is genuinely useful; the issue here is narrow and I think fixable.

## The principle

tweakcc-fixed rewrites the user's installed Claude Code binary. Most patches restyle output, but a few change how the **model** behaves — and some of those are **on by default, with no UI toggle and no mention at apply time**. A user who runs `--apply` having selected nothing still gets them, silently.

## Three tiers of visibility — and one patch sits in the worst

Not all default-on patches are equal. `src/ui/components/MiscView.tsx` shows three distinct tiers:

1. **Visible + opt-in** — e.g. `swap-ripgrep-for-fff`: a real toggle row (`MiscView.tsx:443`), defaults **off** (`defaultSettings.ts:86`). You see it; you choose it. Honest.
2. **Visible + default-on** — ships on, but at least renders as a toggle a user could find and switch off. Questionable, but discoverable.
3. **Invisible + default-on** — `claudemd-context-once-per-conversation` appears in `MiscView.tsx` **only** at line 97, inside the bare defaults object (`claudemdContextOncePerConversation: true`): **no `title:`, no row, no handler.** It is never rendered as a control. So it is *invisible in the UI* **and** *pre-set to ON*. The only ways to learn it exists are reading the source or `--list-patches`; the only way to turn it off is hand-editing `config.json`.

A cosmetic patch in tier 3 would be a nitpick. A **model-input rewrite** in tier 3 — a change to how the user's instructions reach the model, that they cannot see, cannot toggle from the menu, and never chose — is the actual concern.

**Scope:** this isn't one stray patch. A bare `--apply` with nothing selected applies ~13 default-on / always-applied patches *plus* ~11 per-turn `<system-reminder>` rewrites — `claudemd-context-once-per-conversation` is just the clearest case (invisible in the UI *and* model-altering). I'm focusing the PR on it for clarity, not because it's isolated.

## The exhibit: `claudemd-context-once-per-conversation`

It rewrites how Claude Code injects CLAUDE.md into the model — from per-API-call to once-per-conversation (the `…unshift(…)` rewrite with the `isMeta` guard in `src/patches/systemReminders.ts`). It is:

- **default-on** — `src/defaultSettings.ts:731` → `claudemdContextOncePerConversation: true`, and the apply condition at `src/patches/index.ts:1216-1219` is `?? true`, so it applies even when the config omits the key.
- **not user-selectable** — tier 3 above: present in `MiscView.tsx` only in the defaults object (line 97), never as a toggle row.
- **fork-only** — absent from upstream Piebald-AI/tweakcc (v4.1.1): `rg claudemd-context-once-per-conversation src/` returns nothing there. A user arriving from upstream has no prior reason to expect it.

## Demonstration (clean room)

Fresh `~/.tweakcc` (no config at all), native CC 2.1.191, a plain `--apply` with nothing selected:

```
# before --apply — the live binary equals the pristine backup; the patch guard is absent
cmp  ~/.local/share/claude/versions/2.1.191  ~/.tweakcc/native-binary.backup    -> identical
rg -a -c 'As you answer the user")===0'  .../versions/2.1.191                    -> 0

# after a plain --apply (selected nothing):
rg -a -c 'As you answer the user")===0'  .../versions/2.1.191                    -> 1
rg -a -c 'tweakcc'                        .../versions/2.1.191                    -> 9
```

The same apply also seeded default `system-reminders/*.md` and rewrote several per-turn `<system-reminder>`s in the binary (the task-list reminder, the MCP-instructions block, the agent-listing block, memory-update, and the "user sent a new message" wrapper) — again, nothing the user picked. The only per-item signal in the entire apply was the closing patch list, which was mostly `✓ unchanged` plus a single `Tool Description: ShowOnboardingRolePicker: 654 fewer chars`.

## The ask

For **behavioral** patches — the ones that alter model-facing behavior, not cosmetic/correctness ones — `--apply` should **announce them before applying**: ideally a one-line confirm, at minimum a clearly-flagged "the following default-on behavioral patches will be applied" notice. And a tier-3 patch (invisible in the UI) that alters model input shouldn't be default-on at all without surfacing it somewhere selectable.

To be clear: this isn't "defaults are wrong." Opinionated defaults are fine, and a visible opt-in like `swap-ripgrep-for-fff` is exactly right. The narrow ask is that **model-behavior** changes be visible and surfaced rather than applied silently.

## This PR (the docs half)

Tags every patch in the "Every patch the fork adds" list with `[default on]` / `[always]` / `[opt-in]` and adds a one-line legend, so the patches that activate without opt-in are visible at a glance. Labels were verified against `src/defaultSettings.ts` and the `ALWAYS_APPLIED` group.

Happy to send the apply-time announcement as a follow-up PR if you're open to it — I wanted to land the docs and check appetite first rather than drop an unsolicited change to the apply flow.
