### PR TITLE
feat(apply): announce model-facing patches after --apply

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -154,6 +154,37 @@ function printPatchResults(
   console.log('');
 }
 
+/**
+ * After an apply, surface the patches that changed model-facing behavior (what
+ * reaches the model / how it reasons) rather than just output styling. Several
+ * of these are on by default with no menu toggle, so without this notice they
+ * would activate on a bare `--apply` with no signal. This is informational
+ * only — no prompt — because `--apply` runs non-interactively (CI, the npx VPS
+ * legs) and a confirm would hang those.
+ */
+function printModelFacingNotice(results: PatchResult[]): void {
+  const modelFacing = results.filter(r => r.applied && r.modelFacing);
+  if (modelFacing.length === 0) return;
+
+  console.log(
+    chalk.yellow(
+      'ℹ These applied patches change model-facing behavior (not just output styling):'
+    )
+  );
+  for (const r of modelFacing) {
+    const description = r.description
+      ? ` ${chalk.dim('—')} ${r.description}`
+      : '';
+    console.log(`    ${chalk.yellow('•')} ${r.name}${chalk.dim(description)}`);
+  }
+  console.log(
+    chalk.dim(
+      '  Several are on by default. Toggle any off in the menu or ~/.tweakcc/config.json, or run --restore to revert everything.'
+    )
+  );
+  console.log('');
+}
+
 const main = async () => {
   const program = new Command();
   program
@@ -430,6 +461,10 @@ async function handleApplyMode(
 
     // Print patch results
     printPatchResults(results, patchFilter);
+
+    // Surface model-facing patches so default-on behavioral changes are never
+    // applied silently.
+    printModelFacingNotice(results);
 
     // Check if any patches failed
     const hasFailures = results.some(r => r.failed);

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -161,6 +161,7 @@ export interface PatchResult {
   skipped?: boolean;
   details?: string;
   description?: string;
+  modelFacing?: boolean;
 }
 
 export interface ApplyCustomizationResult {
@@ -216,6 +217,7 @@ const PATCH_DEFINITIONS = [
     group: PatchGroup.MISC_CONFIGURABLE,
     description:
       'Make "Summarize from here" summarize only the messages after the rewind point (feed the slice, not the whole conversation)',
+    modelFacing: true,
   },
   {
     id: 'fix-rewind-summary-header',
@@ -223,6 +225,7 @@ const PATCH_DEFINITIONS = [
     group: PatchGroup.MISC_CONFIGURABLE,
     description:
       'Label a rewind summary as a deliberate rewind instead of the misleading "ran out of context" header',
+    modelFacing: true,
   },
   {
     id: 'statusline-update-throttle',
@@ -434,6 +437,7 @@ const PATCH_DEFINITIONS = [
     group: PatchGroup.MISC_CONFIGURABLE,
     description:
       'Opus 4.7 sessions default to "max" reasoning effort instead of "xhigh" (override with /effort or CLAUDE_CODE_EFFORT_LEVEL)',
+    modelFacing: true,
   },
   {
     id: 'autonomous-operation-all-models',
@@ -441,6 +445,7 @@ const PATCH_DEFINITIONS = [
     group: PatchGroup.MISC_CONFIGURABLE,
     description:
       'Treats your selected model as Fable/Mythos everywhere CC branches on model family (flips the zQ gate): you get the autonomous-operation prompt (proceed without asking for reversible in-scope work; finish the job before ending the turn), the "# Communicating with the user" comms block in place of "# Text output", /loop dynamic-pacing behavior, and brief-mode comms shaping. Per-model feature-flag routing also follows fable but is inert on a local install',
+    modelFacing: true,
   },
   {
     id: 'auto-mode-classifier-model',
@@ -448,6 +453,7 @@ const PATCH_DEFINITIONS = [
     group: PatchGroup.MISC_CONFIGURABLE,
     description:
       'Pin auto-mode bash safety classifier to Sonnet 4.6 or Haiku 4.5 instead of the user main-loop model (avoids Opus 4.7 congestion denying tool calls)',
+    modelFacing: true,
   },
   // Features
   {
@@ -456,6 +462,7 @@ const PATCH_DEFINITIONS = [
     group: PatchGroup.FEATURES,
     description:
       'Auto-route reasoning effort (thinking depth) by task complexity: routine work runs at low effort, the top tier only for genuinely frontier problems. Rides on your current model - no model switch, no prompt-cache churn. A one-shot Haiku side-call routes each prompt using a rolling TL;DR summary of the session (so terse follow-ups that continue hard work stay elevated; persisted across resume, reseeded from the main model summary on compaction). While on it drives effort, overriding your saved effortLevel default; an in-session /effort or CLAUDE_CODE_EFFORT_LEVEL still wins. Off by default.',
+    modelFacing: true,
   },
   {
     id: 'allow-custom-agent-models',
@@ -491,6 +498,7 @@ const PATCH_DEFINITIONS = [
     group: PatchGroup.FEATURES,
     description:
       'Enable dream (/dream + auto-dream background memory consolidation)',
+    modelFacing: true,
   },
   {
     id: 'lean-memory-types',
@@ -498,6 +506,7 @@ const PATCH_DEFINITIONS = [
     group: PatchGroup.FEATURES,
     description:
       'Compact "Types of memory" prompt block + on-demand memory-types skill',
+    modelFacing: true,
   },
   {
     id: 'toolsets',
@@ -555,6 +564,7 @@ const PATCH_DEFINITIONS = [
     group: PatchGroup.SYSTEM_REMINDERS,
     description:
       'Kill the "deferred tools are now available via ToolSearch" announcement. WARNING: MCP/Cron/EnterPlanMode/WebFetch/Monitor become invisible to the model unless explicitly named.',
+    modelFacing: true,
   },
   {
     id: 'claudemd-context-once-per-conversation',
@@ -562,6 +572,7 @@ const PATCH_DEFINITIONS = [
     group: PatchGroup.SYSTEM_REMINDERS,
     description:
       'Inject the claudeMd / userEmail / currentDate <system-reminder> only on the first API call per conversation (re-fires after /clear). Default: ON. Toggle OFF for vanilla CC per-turn injection.',
+    modelFacing: true,
   },
 ] as const;
 
@@ -574,6 +585,13 @@ export interface PatchDefinition {
   name: string;
   group: PatchGroup;
   description: string;
+  /**
+   * True for patches that change how the model behaves (what reaches its
+   * context, how it reasons), as opposed to cosmetic output styling or pure
+   * correctness fixes. `--apply` surfaces the model-facing patches it applied
+   * so they are never activated silently. See printModelFacingNotice.
+   */
+  modelFacing?: boolean;
 }
 
 /**
@@ -666,6 +684,7 @@ const applyPatchImplementations = (
       applied,
       failed,
       description: def.description,
+      modelFacing: (def as PatchDefinition).modelFacing,
     });
   }
 

--- a/src/patches/modelFacingNotice.test.ts
+++ b/src/patches/modelFacingNotice.test.ts
@@ -1,0 +1,79 @@
+// Guards the model-facing patch metadata that drives the `--apply` notice
+// (printModelFacingNotice in src/index.tsx). The notice surfaces default-on
+// behavioral patches so they are never applied silently — these assertions
+// pin which patches count as model-facing and verify the filter the notice
+// uses (applied && modelFacing).
+import { describe, expect, it } from 'vitest';
+
+import { getAllPatchDefinitions, PatchGroup, PatchResult } from './index';
+
+const MODEL_FACING_IDS = [
+  'fix-summarize-from-here',
+  'fix-rewind-summary-header',
+  'max-effort-default',
+  'autonomous-operation-all-models',
+  'auto-mode-classifier-model',
+  'complexity-router',
+  'dream-mode',
+  'lean-memory-types',
+  'suppress-deferred-tools',
+  'claudemd-context-once-per-conversation',
+];
+
+describe('model-facing patch metadata', () => {
+  const defs = getAllPatchDefinitions();
+  const byId = new Map(defs.map(d => [d.id, d]));
+
+  it('marks exactly the expected patches as model-facing', () => {
+    const flagged = defs
+      .filter(d => d.modelFacing)
+      .map(d => d.id)
+      .sort();
+    expect(flagged).toEqual([...MODEL_FACING_IDS].sort());
+  });
+
+  it('leaves cosmetic / correctness-only patches unflagged', () => {
+    // Pure output styling and tool-cap tweaks must not trip the behavioral
+    // notice, or it becomes noise the user learns to ignore.
+    for (const id of [
+      'verbose-property',
+      'thinking-block-styling',
+      'statusline-update-throttle',
+      'read-default-lines',
+      'swap-ripgrep-for-fff',
+    ] as const) {
+      expect(byId.get(id)?.modelFacing).toBeFalsy();
+    }
+  });
+
+  it('the notice filter selects only applied model-facing results', () => {
+    const results: PatchResult[] = [
+      {
+        id: 'claudemd-context-once-per-conversation',
+        name: 'claudeMd context: once per conversation',
+        group: PatchGroup.SYSTEM_REMINDERS,
+        applied: true,
+        modelFacing: true,
+      },
+      {
+        id: 'dream-mode',
+        name: 'Dream mode',
+        group: PatchGroup.FEATURES,
+        applied: false, // not applied -> excluded
+        modelFacing: true,
+      },
+      {
+        id: 'verbose-property',
+        name: 'Verbose property',
+        group: PatchGroup.ALWAYS_APPLIED,
+        applied: true, // applied but cosmetic -> excluded
+        modelFacing: false,
+      },
+    ];
+
+    const surfaced = results
+      .filter(r => r.applied && r.modelFacing)
+      .map(r => r.id);
+    expect(surfaced).toEqual(['claudemd-context-once-per-conversation']);
+  });
+});


### PR DESCRIPTION
Follow-up to the apply-time half of #22 (the docs half is voidfreud's PR). `--apply` now announces the patches that change model-facing behavior, so default-on behavioral changes are never activated silently.

## What it does

After the patch-results listing, `--apply` prints a flagged notice listing only the patches that **actually applied** *and* change model-facing behavior, with how to turn them off:

```
ℹ These applied patches change model-facing behavior (not just output styling):
    • Honest rewind summary header — ...
    • Fable/Mythos prompt set (all models) — ...
    • claudeMd context: once per conversation — ...
  Several are on by default. Toggle any off in the menu or ~/.tweakcc/config.json, or run --restore to revert everything.
```

## How

- `modelFacing?: boolean` on `PatchDefinition`, set on the behavioral patches; threaded through `PatchResult`.
- `printModelFacingNotice(results)` in the apply flow filters `applied && modelFacing`.

Marked model-facing: `fix-summarize-from-here`, `fix-rewind-summary-header`, `max-effort-default`, `autonomous-operation-all-models`, `auto-mode-classifier-model`, `complexity-router`, `dream-mode`, `lean-memory-types`, `suppress-deferred-tools`, `claudemd-context-once-per-conversation`. Cosmetic and correctness-only patches stay unflagged so the notice doesn't turn into noise.

## Why a notice, not a confirm

#22 offered "ideally a one-line confirm, at minimum a notice." It's a notice on purpose: `--apply` runs non-interactively in CI and on the npx VPS mirrors, where a prompt would hang. The notice reflects what *actually* applied (a default-on patch whose anchor wasn't found won't be listed), which a pre-apply confirm couldn't.

## Verification

- `pnpm lint` + `pnpm test` green — 787 pass, incl. new `modelFacingNotice.test.ts` pinning the flagged set and the `applied && modelFacing` filter.
- Real native `--apply` on 2.1.191 prints the notice; patched binary boots.
