### PR TITLE
chore(misc): remove dead enableSwarmMode option

### DIFF
--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -725,7 +725,6 @@ export const DEFAULT_SETTINGS: Settings = {
     statuslineThrottleMs: null,
     statuslineUseFixedInterval: false,
     tableFormat: 'default',
-    enableSwarmMode: true,
     enableSessionMemory: true,
     enableDreamMode: true,
     enableLeanMemoryTypes: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,7 +127,6 @@ export interface MiscConfig {
   statuslineThrottleMs: number | null;
   statuslineUseFixedInterval: boolean;
   tableFormat: TableFormat;
-  enableSwarmMode: boolean;
   enableSessionMemory: boolean;
   enableDreamMode: boolean;
   enableLeanMemoryTypes: boolean;

--- a/src/ui/components/MiscView.tsx
+++ b/src/ui/components/MiscView.tsx
@@ -70,7 +70,6 @@ export function MiscView({ onSubmit }: MiscViewProps) {
     statuslineThrottleMs: null as number | null,
     statuslineUseFixedInterval: false,
     tableFormat: 'default' as TableFormat,
-    enableSwarmMode: true,
     enableSessionMemory: true,
     enableDreamMode: true,
     enableLeanMemoryTypes: false,


### PR DESCRIPTION
## What
`enableSwarmMode` is a Misc option wired to nothing — this removes its three declarations.

## Why it's dead
It appears in exactly three places, all declarations:
- `src/types.ts` — the `MiscConfig` field
- `src/defaultSettings.ts` — seeded `true`
- `src/ui/components/MiscView.tsx` — the `defaultMisc` backfill (not a rendered toggle row)

Nothing consumes it: no patch in `patchImplementations` references it, no `MiscItem` toggle renders it, and it produces no patch id. Toggling it on/off changes no patched output. (Unrelated: `swarmBanner` in `inputBorderBox.ts` handles CC's *own* native swarm banner and never reads this flag.)

## Reproduction
```
rg -n "enableSwarmMode" src
#   only: types.ts, defaultSettings.ts, MiscView.tsx (all declarations)
rg -c "enableSwarmMode" src/patches/index.ts        # 0  (orchestrator never reads it)
node dist/index.mjs --list-patches --json | jq -r '.[].id' | rg -i swarm   # (empty)
```

## Change
Three deletions, no behavior change. `tsc --noEmit`, `eslint`, and the full vitest suite (784 passing) stay green.
