### PR TITLE
chore: remove unused exported symbols

### DIFF
--- a/src/installationDetection.ts
+++ b/src/installationDetection.ts
@@ -811,27 +811,8 @@ export async function selectAndSaveInstallation(
 }
 
 /**
- * Gets candidates for display in non-interactive error messages.
- * This re-collects candidates, used when we need to show what was found.
- */
-export async function getCandidatesForError(): Promise<
-  InstallationCandidate[]
-> {
-  return collectCandidates();
-}
-
-/**
  * Formats the "not found" error message for display.
  */
 export function formatNotFoundError(): string {
   return getNotFoundError();
-}
-
-/**
- * Formats the "multiple candidates" error message for display.
- */
-export function formatMultipleCandidatesError(
-  candidates: InstallationCandidate[]
-): string {
-  return getMultipleCandidatesError(candidates);
 }

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -134,12 +134,6 @@ export interface LocationResult {
   identifiers?: string[];
 }
 
-export interface ModificationEdit {
-  startIndex: number;
-  endIndex: number;
-  newContent: string;
-}
-
 // =============================================================================
 // Patch Group and Result Types
 // =============================================================================
@@ -606,15 +600,6 @@ export const getAllPatchDefinitions = (): PatchDefinition[] => {
 interface PatchImplementation {
   fn: (content: string) => string | null;
   condition?: boolean;
-}
-
-// =============================================================================
-// Legacy types (for backward compatibility with patchesAppliedIndication)
-// =============================================================================
-
-export interface PatchApplied {
-  newContent: string;
-  items: string[];
 }
 
 // =============================================================================

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -7,8 +7,6 @@ import {
 import { doesFileExist } from './utils';
 import {
   CLIJS_BACKUP_FILE,
-  CONFIG_DIR,
-  CONFIG_FILE,
   NATIVE_BINARY_BACKUP_FILE,
   readConfigFile,
 } from './config';
@@ -147,28 +145,3 @@ export async function completeStartupCheck(
     ccInstInfo,
   };
 }
-
-export const createExampleConfigIfMissing = async (
-  examplePath: string
-): Promise<void> => {
-  try {
-    await fs.mkdir(CONFIG_DIR, { recursive: true });
-    // Only create if config file doesn't exist
-    try {
-      await fs.stat(CONFIG_FILE);
-    } catch (error) {
-      if (
-        error instanceof Error &&
-        'code' in error &&
-        error.code === 'ENOENT'
-      ) {
-        const exampleConfig = {
-          ccInstallationPath: examplePath + '/cli.js',
-        };
-        await fs.writeFile(CONFIG_FILE, JSON.stringify(exampleConfig, null, 2));
-      }
-    }
-  } catch {
-    // Silently fail if we can't write the config file
-  }
-};

--- a/src/systemPromptDownload.ts
+++ b/src/systemPromptDownload.ts
@@ -164,26 +164,3 @@ export async function downloadStringsFile(
     throw error;
   }
 }
-
-/**
- * Downloads strings files for multiple versions
- * @param versions - Array of version strings
- * @returns Promise that resolves to a map of version to parsed JSON content
- */
-export async function downloadMultipleStringsFiles(
-  versions: string[]
-): Promise<Map<string, StringsFile>> {
-  const results = new Map<string, StringsFile>();
-
-  for (const version of versions) {
-    try {
-      const data = await downloadStringsFile(version);
-      results.set(version, data);
-    } catch (error) {
-      console.error(`Failed to download version ${version}:`, error);
-      // Continue with other versions
-    }
-  }
-
-  return results;
-}

--- a/src/systemPromptHashIndex.ts
+++ b/src/systemPromptHashIndex.ts
@@ -149,34 +149,6 @@ export const getPromptHash = async (
 };
 
 /**
- * Checks if a markdown file's content (excluding frontmatter) matches the expected hash
- *
- * @param markdownContent - The full content of a markdown file with frontmatter
- * @param expectedHash - The expected MD5 hash
- * @returns true if the content matches the hash (unmodified), false otherwise
- */
-export const verifyMarkdownHash = (
-  markdownContent: string,
-  expectedHash: string
-): boolean => {
-  // Extract content after frontmatter
-  const frontmatterMatch = markdownContent.match(
-    /^---\n[\s\S]+?\n---\n([\s\S]*)$/
-  );
-
-  if (!frontmatterMatch) {
-    // No frontmatter found - hash the entire content
-    const hash = computeMD5Hash(markdownContent.trim());
-    return hash === expectedHash;
-  }
-
-  // Hash only the content part (after frontmatter), trimmed
-  const contentOnly = frontmatterMatch[1].trim();
-  const hash = computeMD5Hash(contentOnly);
-  return hash === expectedHash;
-};
-
-/**
  * Structure of the applied hashes file
  * Maps: "prompt-id" => "md5hash" | null
  * Example: "main-system-prompt" => "a1b2c3..." or null if not applied/defaults restored
@@ -197,16 +169,6 @@ export const readAppliedHashIndex = async (): Promise<AppliedHashIndex> =>
 export const writeAppliedHashIndex = async (
   index: AppliedHashIndex
 ): Promise<void> => writeJsonIndexFileAtomic(getAppliedHashesPath(), index);
-
-/**
- * Updates the applied hash for a specific prompt ID
- */
-export const setAppliedHash = async (
-  promptId: string,
-  hash: string
-): Promise<void> => {
-  await setAppliedHashes({ [promptId]: hash });
-};
 
 export const setAppliedHashes = async (
   updates: Record<string, string>
@@ -232,17 +194,6 @@ export const clearAllAppliedHashes = async (): Promise<void> => {
   }
 
   await writeAppliedHashIndex(clearedIndex);
-};
-
-/**
- * Gets the applied hash for a specific prompt ID
- * Returns undefined if not found, null if explicitly set to null
- */
-export const getAppliedHash = async (
-  promptId: string
-): Promise<string | null | undefined> => {
-  const index = await readAppliedHashIndex();
-  return index[promptId];
 };
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,6 @@ import * as path from 'path';
 import * as os from 'os';
 import * as child_process from 'child_process';
 import * as crypto from 'crypto';
-import { Theme } from './types';
 import { CUSTOM_MODELS } from './patches/modelSelector';
 
 let isDebugModeOn = false;
@@ -137,10 +136,6 @@ export function getSelectedModel(): string {
   }
 
   return 'Opus 4.5';
-}
-
-export function getColorKeys(theme: Theme): string[] {
-  return Object.keys(theme.colors);
 }
 
 export function openInExplorer(filePath: string) {


### PR DESCRIPTION
## What

Removes **10 exported symbols that are referenced nowhere** in the codebase, plus the 3 imports their removal orphaned. Pure deletions — no behavior change.

## Why they're dead (evidence)

Each of the 10 appears **exactly once** across the entire repo — its own definition, with **zero callers** anywhere in `src/`, including tests. They're invisible to `tsc` and `eslint` precisely *because* they're `export`ed (an unused export isn't flagged), which is how they accumulated unnoticed. None are part of the published API surface (`src/lib/index.ts`), so no external consumer can import them either.

Reproduction (run on `main` — each prints `1`, i.e. definition only):

```bash
for n in getAppliedHash setAppliedHash verifyMarkdownHash getCandidatesForError \
  formatMultipleCandidatesError createExampleConfigIfMissing downloadMultipleStringsFiles \
  getColorKeys ModificationEdit PatchApplied; do
  echo "$n: $(rg -wc "\b$n\b" --glob '!dist/**' --glob '!node_modules/**' . | awk -F: '{s+=$2}END{print s+0}')"
done
```

The word-boundary search also catches string / dynamic references (e.g. `obj["getAppliedHash"]`) — a count of 1 means there are none.

## The 10, split by how clear-cut they are

**Unambiguously dead — helpers/formatters with no caller and no obvious future hook:**
| Symbol | File |
|---|---|
| `getCandidatesForError`, `formatMultipleCandidatesError` | `installationDetection.ts` (error-message helpers) |
| `createExampleConfigIfMissing` | `startup.ts` |
| `downloadMultipleStringsFiles` | `systemPromptDownload.ts` |
| `getColorKeys` | `utils.ts` |

**Also dead today, but they *read* like they may have been stubbed for later — your call:**
| Symbol | File | Note |
|---|---|---|
| `getAppliedHash`, `setAppliedHash`, `verifyMarkdownHash` | `systemPromptHashIndex.ts` | an applied-hash get/set/verify trio; the rest of that module (`setAppliedHashes`, `clearAllAppliedHashes`, `hasUnappliedSystemPromptChanges`, …) is alive and used — only these three have no caller |
| `ModificationEdit`, `PatchApplied` | `patches/index.ts` | unused interfaces (`PatchApplied` sat under a "legacy types for backward compatibility" comment, but nothing imports it) |

If any of the second group are intentional placeholders for upcoming work, say the word and I'll drop them from this PR and keep only the first group. They're safe to remove today either way — the distinction is intent, not correctness.

## How this was verified (testing)

After deleting all 10 + the 3 orphaned imports (`CONFIG_DIR`, `CONFIG_FILE`, `Theme`), on a branch off current `main`:

- `tsc --noEmit` — **passes** (nothing referenced them at the type level)
- `eslint src tools` — **passes** (no unused/undefined fallout)
- `vitest run` — **787 passed, 5 skipped, 0 failed**
- `git diff` — **138 deletions, 0 insertions** across 6 files (pure removal)

For unused-symbol removal, a green `tsc` + `eslint` + full suite is conclusive: there's no runtime path to a symbol the compiler confirms is unreferenced.

## Impact on the project

No behavior change — nothing called these, so nothing changes at runtime. The benefit is an **honest surface**: ~138 fewer lines of dead code, and the next reader (or grep, or refactor) won't be misled into thinking these are live API. Lowest-risk class of change there is.
