### PR TITLE
fix(native): no more binary bloat when patching Linux installs

### DIFF
--- a/src/nativeInstallation.ts
+++ b/src/nativeInstallation.ts
@@ -1474,13 +1474,32 @@ function repackELFSection(
     const pageSize = elfBinary.pageSize();
     const newContentSize = BigInt(newSectionData.length);
     const alignedNewSize = alignBigInt(newContentSize, pageSize);
-    const newVaddr = alignBigInt(elfBinary.nextVirtualAddress(), pageSize);
-    const offsetInSegment = newVaddr - rwSegment.virtualAddress;
-    const newFileOffset = rwSegment.fileOffset + offsetInSegment;
+    const oldBunFileOffset = BigInt(bunSection.fileOffset);
+    const SHF_ALLOC = 0x2n;
+    const allocSectionAtOrAfterBun = elfBinary
+      .sections()
+      .some(
+        s =>
+          s.name !== '.bun' &&
+          (BigInt(s.flags) & SHF_ALLOC) !== 0n &&
+          BigInt(s.virtualAddress) >= oldBunSectionVaddr
+      );
+
+    let newVaddr: bigint;
+    let newFileOffset: bigint;
+    if (allocSectionAtOrAfterBun) {
+      newVaddr = alignBigInt(elfBinary.nextVirtualAddress(), pageSize);
+      newFileOffset =
+        rwSegment.fileOffset + (newVaddr - rwSegment.virtualAddress);
+    } else {
+      newVaddr = oldBunSectionVaddr;
+      newFileOffset = oldBunFileOffset;
+    }
+
     const oldRwFileEnd = rwSegment.fileOffset + rwSegment.fileSize;
     const extensionSize = newFileOffset + alignedNewSize - oldRwFileEnd;
 
-    if (extensionSize < 0n) {
+    if (extensionSize < 0n && allocSectionAtOrAfterBun) {
       throw new Error(
         'New .bun location overlaps existing writable ELF segment'
       );

--- a/src/patches/nativeRepackSize.test.ts
+++ b/src/patches/nativeRepackSize.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { readContent, writeContent } from '../lib/content';
+import type { Installation } from '../lib/types';
+
+const PRISTINE = process.env.TWEAKCC_PRISTINE_BINARY;
+const run = PRISTINE && fs.existsSync(PRISTINE) ? describe : describe.skip;
+
+run('native repack size regression', () => {
+  let scratch: string;
+  let work: string;
+  let pristineSize: number;
+
+  beforeAll(() => {
+    scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'tweakcc-size-'));
+    work = path.join(scratch, 'claude-copy');
+    fs.copyFileSync(PRISTINE!, work);
+    fs.chmodSync(work, 0o755);
+    pristineSize = fs.statSync(work).size;
+  });
+
+  const inst = (): Installation => ({
+    kind: 'native',
+    path: work,
+    version: '0.0.0',
+  });
+
+  it('grows the binary only by the injected-JS delta, not a whole blob copy', async () => {
+    const { content, clearBytecode } = await readContent(inst());
+    const patched = content + '\n// __tweakcc_size_test__\n';
+    await writeContent(inst(), patched, clearBytecode);
+    const afterApply = fs.statSync(work).size;
+
+    const grewBy = afterApply - pristineSize;
+    expect(grewBy).toBeGreaterThanOrEqual(0);
+    expect(grewBy).toBeLessThan(8 * 1024 * 1024);
+    expect(grewBy).toBeLessThan(pristineSize / 4);
+  });
+
+  it('does not accumulate across repeated write passes (downstream writer)', async () => {
+    const sizeBefore = fs.statSync(work).size;
+    const { content, clearBytecode } = await readContent(inst());
+    await writeContent(inst(), content, clearBytecode);
+    const sizeAfter = fs.statSync(work).size;
+    expect(sizeAfter).toBe(sizeBefore);
+  });
+
+  it('returns to ~pristine size when the original JS is written back', async () => {
+    const freshCopy = path.join(scratch, 'claude-fresh');
+    fs.copyFileSync(PRISTINE!, freshCopy);
+    fs.chmodSync(freshCopy, 0o755);
+    const { content: pristineJs } = await readContent({
+      kind: 'native',
+      path: freshCopy,
+      version: '0.0.0',
+    });
+
+    const { clearBytecode } = await readContent(inst());
+    await writeContent(inst(), pristineJs, clearBytecode);
+    const restored = fs.statSync(work).size;
+
+    expect(Math.abs(restored - pristineSize)).toBeLessThan(1024 * 1024);
+  });
+});


### PR DESCRIPTION
## Summary
Patching a native (Bun) install on Linux made the binary balloon — one apply
took a ~275 MB binary to ~723 MB, and each extra write pass grew it further
(up to 1.26 GB).

## Changes
- `repackELFSection` writes the `.bun` section back in its own place instead of
  appending a fresh copy at `nextVirtualAddress()` (which LIEF rounds up to a
  256 MB boundary, leaving the old section + a big gap as dead weight).
- Falls back to the old append behavior if another ALLOC section sits at/after
  `.bun`, so correctness is never traded for size.
- Adds a gated size-regression test (`TWEAKCC_PRISTINE_BINARY`).

## Testing
- [x] Tests added/updated
- [x] Manual testing completed
- [x] All existing tests pass

Linux/ELF pristine 2.1.220 (also 2.1.214/2.1.219): apply +24 KB (was +448 MB),
2nd write pass +0, restore ~pristine, boots clean.

## Related Issues
N/A