### PR TITLE
Fix writeContent on Claude Code 2.1.257+ Linux ELF: fall back to pointer-aligned BUN_COMPILED scan

### DIFF
--- a/src/nativeInstallation.ts
+++ b/src/nativeInstallation.ts
@@ -1800,26 +1800,37 @@ function repackELFSection(
     const vaddrBytes = Buffer.alloc(8);
     vaddrBytes.writeBigUInt64LE(oldBunSectionVaddr);
 
-    let bunCompiledVaddr: bigint | null = null;
     const rwContent = rwSegment.content;
     const rwVaddrStart = rwSegment.virtualAddress;
-    const firstAligned = alignBigInt(
-      rwVaddrStart,
-      BigInt(BLOB_HEADER_ALIGNMENT)
-    );
-    const lastCandidate = rwVaddrStart + BigInt(rwContent.length) - 8n;
+    // Stop at the .bun section start when it maps inside this segment so
+    // payload bytes cannot alias the marker.
+    const rwVaddrEnd = rwVaddrStart + BigInt(rwContent.length);
+    const scanEnd =
+      oldBunSectionVaddr > rwVaddrStart && oldBunSectionVaddr < rwVaddrEnd
+        ? oldBunSectionVaddr
+        : rwVaddrEnd;
 
-    for (
-      let va = firstAligned;
-      va <= lastCandidate;
-      va += BigInt(BLOB_HEADER_ALIGNMENT)
-    ) {
-      const off = Number(va - rwVaddrStart);
-      if (rwContent.subarray(off, off + 8).equals(vaddrBytes)) {
-        bunCompiledVaddr = va;
-        break;
+    const findMarker = (alignment: bigint): bigint | null => {
+      for (
+        let off = rwContent.indexOf(vaddrBytes);
+        off !== -1;
+        off = rwContent.indexOf(vaddrBytes, off + 1)
+      ) {
+        const va = rwVaddrStart + BigInt(off);
+        if (va + 8n > scanEnd) {
+          return null;
+        }
+        if (va % alignment === 0n) {
+          return va;
+        }
       }
-    }
+      return null;
+    };
+
+    // Current builds emit BUN_COMPILED at pointer alignment (sh_addralign =
+    // 8) despite declaring BLOB_HEADER_ALIGNMENT; retry at 8 when needed.
+    const bunCompiledVaddr =
+      findMarker(BigInt(BLOB_HEADER_ALIGNMENT)) ?? findMarker(8n);
 
     if (bunCompiledVaddr === null) {
       throw new Error(


### PR DESCRIPTION
## Problem

`writeContent` throws on Claude Code 2.1.257 and 2.1.258 Linux x64 native builds — even on a zero-change `readContent` -> `writeContent` round trip:

```
Error: Could not find original BUN_COMPILED location in binary (searched for 0x5541000)
```

`readContent` works perfectly on these builds (full 32.4 MB bundle).

## Root cause

`repackELFSection` scans the RW `PT_LOAD` segment for the 8-byte LE `.bun` vaddr in `BLOB_HEADER_ALIGNMENT` (16384) strides at 16k-aligned vaddrs. The 2.1.257+ Bun toolchain emits BUN_COMPILED with plain 8-byte alignment (`.bun` `sh_addralign = 8`); the marker sits at vaddr `0x534f758` (`va % 16384 = 14168`), so the coarse scan never lands on it. These builds also map `.bun` inside the same RW segment, so a finer scan must stop at the `.bun` section start to avoid matching inside the payload.

## Fix

Try the `BLOB_HEADER_ALIGNMENT` stride first (unchanged behavior for older builds), then fall back to a pointer-aligned (8-byte) `Buffer.indexOf` scan capped at the `.bun` section start when `.bun` lies inside the RW segment. No hardcoded offsets.

## Verification (Linux x64, through the built dist)

- 2.1.257: read -> single string-literal change -> write -> repacked binary executes (`--version` prints `2.1.257 (Claude Code)`), edited literal present exactly once.
- 2.1.258: same flow passes.
- Zero-change round trip repacks and executes.
- `tsc --noEmit` and eslint clean; older-build behavior untouched (16384-stride path tried first).

Happy to adjust style or add tests if you point me at the preferred harness.